### PR TITLE
Make bootstrap collapse elements work on iPads

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -21,6 +21,11 @@
     }
 }
 
+[data-toggle~="collapse"] {
+    // required to make collapse divs work on iPad
+    cursor: pointer;
+}
+
 .avatar {
     @extend .rounded-circle;
     width: 96px;


### PR DESCRIPTION
See https://makandracards.com/makandra/34753-how-to-fix-ipad-does-not-trigger-click-event-on-some-elements and https://stackoverflow.com/a/42857999. Fixes part of #36