### PR TITLE
Tagesspick

### DIFF
--- a/app/Http/Controllers/BlockListController.php
+++ b/app/Http/Controllers/BlockListController.php
@@ -15,4 +15,8 @@ class BlockListController extends Controller
     {
         return view('blocks');
     }
+    public function crib()
+    {
+        return view('crib');
+    }
 }

--- a/resources/views/crib.blade.php
+++ b/resources/views/crib.blade.php
@@ -1,0 +1,75 @@
+@extends('layouts.default')
+
+@section('content')
+
+    @component('components.card', ['header' => __('Welche Mindestanforderungen können in den jeweiligen Blöcken beobachtet werden:')])
+
+
+
+        @if (count($course->blocks))
+
+            @php
+                $days = [];
+                foreach($course->blocks as $block) {
+                    $days[$block->block_date->timestamp][] = $block;
+                }
+            @endphp
+            <div id="accordion">
+
+                @foreach($days as $day)
+                <div class="card">
+                    <div class="card-header" id="heading{{ $day[0]->block_date->timestamp }}">
+                        <h5 class="mb-0" data-toggle="collapse" data-target="#collapse{{ $day[0]->block_date->timestamp }}" aria-expanded="true" aria-controls="collapse{{ $day[0]->block_date->timestamp }}">
+                            {{ $day[0]->block_date->formatLocalized('%A %d.%m.%Y') }}
+                        </h5>
+                    </div>
+
+                    <div id="collapse{{ $day[0]->block_date->timestamp }}" class="collapse{{ ($course->archived || $day[0]->block_date->gt(\Carbon\Carbon::now()->subDays(2))) ? ' show' : '' }}" aria-labelledby="heading{{ $day[0]->block_date->timestamp }}">
+                        <ul class="list-group list-group-flush">
+                            @foreach ($day as $block)
+                                <h5 class="list-group-item mb-0">{{ $block->blockname_and_number }}
+                                    @php $count_requirement= 0 @endphp
+                                    @if(count($block->requirements))
+                                        @foreach($block->requirements as $requirement)
+                                            @if($requirement->mandatory)
+                                                @if(!$count_requirement)
+                                                    <br>
+                                                    {{__('Killer: ')}}
+                                                @endif
+                                                <span class="badge badge-warning" style="white-space: normal"> {{$requirement->content}} </span>
+                                                @php $count_requirement=$count_requirement+1  @endphp
+                                            @endif
+                                        @endforeach
+                                        @if(!(count($block->requirements)==$count_requirement))
+                                            <br>
+                                            {{__('Nicht-Killer: ')}}
+                                            @foreach($block->requirements as $requirement)
+                                                @if(!$requirement->mandatory)
+                                                    <span class="badge badge-info" style="white-space: normal"> {{$requirement->content}} </span>
+                                                    @php $count_requirement=$count_requirement+1 @endphp
+                                                @endif
+                                            @endforeach
+                                        @endif
+                                    @endif
+                                </h5>
+
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+                @endforeach
+            </div>
+            @component('components.help-text', ['header' => __('Siehst du nur leere Blöcke ohne Mindestanforderungen?'), 'collapseId' => 'no-linked-MA'])
+                {{__('Dann sind bisher sind Blöcke mit Mindesanforderungen verbunden. Bitte verbinde die Blöcke ')}} <a href="{{ route('admin.blocks', ['course' => $course->id]) }}">{{__('hier')}}</a>  {{__(' mit Mindestanforderungen')}}.
+
+            @endcomponent
+
+        @else
+
+            {{__('Bisher sind keine Blöcke erfasst. Bitte erfasse und verbinde sie')}} <a href="{{ route('admin.blocks', ['course' => $course->id]) }}">{{__('hier')}}</a>  {{__(' mit Mindestanforderungen')}}.
+
+        @endif
+
+    @endcomponent
+
+@endsection

--- a/resources/views/includes/header.blade.php
+++ b/resources/views/includes/header.blade.php
@@ -25,6 +25,7 @@
                     <li class="nav-item{{ Route::currentRouteName() == 'blocks' ? ' active' : '' }}">
                         <a class="nav-link" href="{{ route('blocks', ['course' => $course->id]) }}">Blöcke</a>
                     </li>
+
                     @if(!$course->archived)
                         <li class="nav-item{{ Route::currentRouteName() == 'participants' ? ' active' : '' }}">
                             <a class="nav-link" href="{{ route('participants', ['course' => $course->id]) }}">TN</a>
@@ -33,6 +34,9 @@
                             <a class="nav-link" href="{{ route('overview', ['course' => $course->id]) }}">Überblick</a>
                         </li>
                     @endif
+                    <li class="nav-item{{ Route::currentRouteName() == 'crib' ? ' active' : '' }}">
+                        <a class="nav-link" href="{{ route('crib', ['course' => $course->id]) }}">Spick</a>
+                    </li>
                     <li class="nav-item dropdown{{ substr( Route::currentRouteName(), 0, 5 ) == 'admin' ? ' active' : '' }}">
                         <a class="nav-link dropdown-toggle" id="navbarCourseAdmin" role="button"
                            data-toggle="dropdown"

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/', 'CourseController@noCourse')->name('home');
-
+    #Route::get('/kitchensink', 'KitchenSinkController@index')->name('pages.kitchensink');
     Route::get('/course', 'CourseController@noCourse');
     Route::get('/user', 'HomeController@editUser')->name('user');
     Route::post('/user', 'HomeController@updateUser')->name('user.update');
@@ -25,6 +25,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/course/{course}', 'HomeController@index')->name('index');
 
     Route::get('/course/{course}/blocks', 'BlockListController@index')->name('blocks');
+    Route::get('/course/{course}/crib', 'BlockListController@crib')->name('crib');
 
     Route::middleware('courseNotArchived')->group(function () {
         Route::get('/course/{course}/participants', 'ParticipantListController@index')->name('participants');

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Facades\Route;
 Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/', 'CourseController@noCourse')->name('home');
-    #Route::get('/kitchensink', 'KitchenSinkController@index')->name('pages.kitchensink');
     Route::get('/course', 'CourseController@noCourse');
     Route::get('/user', 'HomeController@editUser')->name('user');
     Route::post('/user', 'HomeController@updateUser')->name('user.update');

--- a/tests/Feature/Crib/ReadCribTest.php
+++ b/tests/Feature/Crib/ReadCribTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Crib;
+
+use App\Models\Participant;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Tests\TestCaseWithCourse;
+
+class ReadCribTest extends TestCaseWithCourse {
+
+    protected $safetyRequirementId;
+    protected $basicsRequirementId;
+    protected $beNiceRequirementId;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->safetyRequirementId = $this->createRequirement('Sicherheitsüberlegungen', true);
+        $this->basicsRequirementId = $this->createRequirement('Beziehungen und Methoden', true);
+        $this->beNiceRequirementId = $this->createRequirement('Nett sein', false);
+    }
+
+    public function test_shouldRequireLogin() {
+        // given
+        auth()->logout();
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
+    }
+
+    public function test_shouldDisplayMessage_whenNoBlocksInCourse() {
+        // given
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertOk();
+        $response->assertSee('Bisher sind keine Blöcke erfasst. Bitte erfasse und verbinde sie ');
+    }
+
+    public function test_shouldDisplay_blockWithNoConnectedRequirement() {
+        // given
+        $this->createBlock('Block 1', '1.1', '01.01.2019');
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertOk();
+        $response->assertSee('Block 1');
+        $response->assertDontSee('Sicherheitsüberlegungen');
+        $response->assertDontSee('Beziehungen und Methoden');
+        $response->assertDontSee('Nett sein');
+    }
+
+    public function test_shouldDisplay_blockWithConnectedRequirement() {
+        // given
+        $this->createBlock('Block 1', '1.1', '01.01.2019', [$this->safetyRequirementId]);
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertOk();
+        $response->assertSee('Block 1');
+        $this->assertSeeAllInOrder('span.badge.badge-warning', ['Sicherheitsüberlegungen']);
+        $response->assertDontSee('Beziehungen und Methoden');
+        $response->assertDontSee('Nett sein');
+    }
+
+    public function test_shouldDisplay_blockWithMultipleConnectedRequirements() {
+        // given
+        $this->createBlock('Block 1', '1.1', '01.01.2019', [$this->safetyRequirementId, $this->basicsRequirementId, $this->beNiceRequirementId]);
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertOk();
+        $response->assertSee('Block 1');
+        $this->assertSeeAllInOrder('span.badge.badge-warning', ['Sicherheitsüberlegungen', 'Beziehungen und Methoden']);
+        $this->assertSeeAllInOrder('span.badge.badge-info', ['Nett sein']);
+    }
+
+    public function test_shouldDisplayMessage_whenBlocksInCourse() {
+        // given
+        $this->createBlock('Block 1', '1.1', '01.01.2019');
+
+        // when
+        $response = $this->get('/course/' . $this->courseId . '/crib');
+
+        // then
+        $response->assertOk();
+        $response->assertSee('Siehst du nur leere Blöcke ohne Mindestanforderungen?');
+    }
+
+    public function test_shouldNotDisplayCrib_toOtherUser() {
+        // given
+        $otherKursId = $this->createCourse('Zweiter Kurs', '', false);
+        Participant::create(['course_id' => $otherKursId, 'scout_name' => 'Pflock']);
+
+        // when
+        $response = $this->get('/course/' . $otherKursId . '/crib');
+
+        // then
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+}


### PR DESCRIPTION
Tagesspick funktion
- ersichtlich für archivierte und aktive Kurse
- in der Navigation nach relevanten Kurstabs und vor Kursadmin
- Keine Tests geschrieben, da Blockübersicht von @carlobeltrame übernommen
- bewusst keine Tabellenansicht gewählt, da die Mindestanforderungen lange Texte sein können und es dann Ellenlange Übersichten geben kann für einen einzelnen Tag. So evtl weniger schön, dafür Platzsparender

Offene Fragen:
- Text  Killer / Nicht Killer nötig? oder irgendwo z.B. unten die Farben erklären?
- Bei der Verlinkung Mindesanforderung / Blöcke hat es keine Übersicht was schon verlinkt ist, man muss dafür in den Block bearbeitungsmodus und es dort anschauen. Allenfalls anpassen?