### PR TITLE
Connect requirements to blocks

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -38,7 +38,7 @@ class Handler extends ExceptionHandler
      * @throws Exception
      */
     public function report(Exception $exception) {
-        if (app()->bound('sentry') && $this->shouldReport($exception)) {
+        if (!env('APP_DEBUG') && app()->bound('sentry') && $this->shouldReport($exception)) {
             app('sentry')->captureException($exception);
         }
 

--- a/app/Http/Controllers/BlockController.php
+++ b/app/Http/Controllers/BlockController.php
@@ -41,7 +41,7 @@ class BlockController extends Controller {
             $data = $request->validated();
             $block = Block::create(array_merge($data, ['course_id' => $course->id]));
 
-            $block->requirements()->attach(array_filter(explode(',', $data['requirement_ids'])));
+            $block->requirements()->attach(array_filter(explode(',', $data['requirements'])));
 
             /** @var User $user */
             $user = Auth::user();
@@ -120,7 +120,7 @@ class BlockController extends Controller {
             $block->update($data);
 
             $block->requirements()->detach(null);
-            $block->requirements()->attach(array_filter(explode(',', $data['requirement_ids'])));
+            $block->requirements()->attach(array_filter(explode(',', $data['requirements'])));
 
             /** @var User $user */
             $user = Auth::user();

--- a/app/Http/Requests/BlockImportRequest.php
+++ b/app/Http/Requests/BlockImportRequest.php
@@ -6,15 +6,13 @@ use App\Providers\ImportServiceProvider;
 use App\Services\Import\Blocks\BlockListImporter;
 use Illuminate\Foundation\Http\FormRequest;
 
-class BlockImportRequest extends FormRequest
-{
+class BlockImportRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -23,8 +21,7 @@ class BlockImportRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'source' => 'required|in:' . implode(',', array_keys(ImportServiceProvider::$BLOCK_IMPORTER_MAP)),
             'file' => 'required|max:2000',
@@ -37,6 +34,6 @@ class BlockImportRequest extends FormRequest
      * @return BlockListImporter
      */
     public function getImporter() {
-       return app()->get(ImportServiceProvider::$BLOCK_IMPORTER_MAP[$this->input('source')]);
+        return app()->get(ImportServiceProvider::$BLOCK_IMPORTER_MAP[$this->input('source')]);
     }
 }

--- a/app/Http/Requests/BlockRequest.php
+++ b/app/Http/Requests/BlockRequest.php
@@ -2,17 +2,17 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Requirement;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class BlockRequest extends FormRequest
-{
+class BlockRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,13 +21,16 @@ class BlockRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'name' => 'required|max:255',
             'full_block_number' => 'regex:/^\d+\.\d+$/|nullable',
             'block_date' => 'date|required',
-            'requirement_ids' => 'regex:/^\d+(,\d+)*$/|nullable',
+            'requirements' => 'nullable|regex:/^\d+(,\d+)*$/|allExistInCourse',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.block');
     }
 }

--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class CategoryRequest extends FormRequest
-{
+class CategoryRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,10 +20,13 @@ class CategoryRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'name' => 'required|max:255',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.category');
     }
 }

--- a/app/Http/Requests/CourseRequest.php
+++ b/app/Http/Requests/CourseRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class CourseRequest extends FormRequest
-{
+class CourseRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,11 +20,14 @@ class CourseRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'name' => 'required|max:255',
             'course_number' => 'max:255',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.course');
     }
 }

--- a/app/Http/Requests/ErrorReportRequest.php
+++ b/app/Http/Requests/ErrorReportRequest.php
@@ -4,15 +4,13 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ErrorReportRequest extends FormRequest
-{
+class ErrorReportRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,8 +19,7 @@ class ErrorReportRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255',

--- a/app/Http/Requests/InvitationClaimRequest.php
+++ b/app/Http/Requests/InvitationClaimRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class InvitationClaimRequest extends FormRequest
-{
+class InvitationClaimRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,10 +20,13 @@ class InvitationClaimRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'token' => 'required|max:128',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.invitation_claim');
     }
 }

--- a/app/Http/Requests/InvitationRequest.php
+++ b/app/Http/Requests/InvitationRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class InvitationRequest extends FormRequest
-{
+class InvitationRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,10 +20,13 @@ class InvitationRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'email' => 'required|email|max:50',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.invitation');
     }
 }

--- a/app/Http/Requests/ObservationRequest.php
+++ b/app/Http/Requests/ObservationRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class ObservationRequest extends FormRequest
-{
+class ObservationRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,15 +20,18 @@ class ObservationRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
-            'participant_ids' => 'required|regex:/^\d+(,\d+)*$/',
+            'participants' => 'required|regex:/^\d+(,\d+)*$/|allExistInCourse',
             'content' => 'required|max:1023',
             'impression' => 'required|in:0,1,2',
-            'block_id' => 'required|numeric',
-            'requirement_ids' => 'regex:/^\d+(,\d+)*$/|nullable',
-            'category_ids' => 'regex:/^\d+(,\d+)*$/|nullable',
+            'block' => 'required|regex:/^\d+$/|existsInCourse',
+            'requirements' => 'nullable|regex:/^\d+(,\d+)*$/|allExistInCourse',
+            'categories' => 'nullable|regex:/^\d+(,\d+)*$/|allExistInCourse',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.observation');
     }
 }

--- a/app/Http/Requests/ParticipantRequest.php
+++ b/app/Http/Requests/ParticipantRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class ParticipantRequest extends FormRequest
-{
+class ParticipantRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,8 +20,7 @@ class ParticipantRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'scout_name' => 'required|max:255',
             'group' => 'max:255',
@@ -42,5 +40,9 @@ class ParticipantRequest extends FormRequest
             unset($validated['image']);
         }
         return $validated;
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.participant');
     }
 }

--- a/app/Http/Requests/RequirementRequest.php
+++ b/app/Http/Requests/RequirementRequest.php
@@ -24,6 +24,7 @@ class RequirementRequest extends FormRequest {
         return [
             'content' => 'required|max:255',
             'mandatory' => 'boolean',
+            'blocks' => 'nullable|regex:/^\d+(,\d+)*$/|allExistInCourse',
         ];
     }
 

--- a/app/Http/Requests/RequirementRequest.php
+++ b/app/Http/Requests/RequirementRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
 class RequirementRequest extends FormRequest {
     /**
@@ -24,5 +25,9 @@ class RequirementRequest extends FormRequest {
             'content' => 'required|max:255',
             'mandatory' => 'boolean',
         ];
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.requirement');
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,16 +3,15 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
 
-class UserRequest extends FormRequest
-{
+class UserRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize() {
         return true;
     }
 
@@ -21,8 +20,7 @@ class UserRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
+    public function rules() {
         return [
             'name' => 'required|max:30',
             'group' => 'max:255',
@@ -42,5 +40,9 @@ class UserRequest extends FormRequest
             unset($validated['image']);
         }
         return $validated;
+    }
+
+    public function attributes() {
+        return Lang::get('t.models.user');
     }
 }

--- a/app/Models/HitobitoUser.php
+++ b/app/Models/HitobitoUser.php
@@ -26,11 +26,6 @@ class HitobitoUser extends User {
     public function __construct(...$args) {
         $this->fillable[] = 'hitobito_id';
         parent::__construct(...$args);
-    }
-
-    public function newInstance($attributes = [], $exists = false) {
-        return tap(parent::newInstance($attributes, $exists), function ($instance) {
-            $instance->email_verified_at = Carbon::now();
-        });
+        $this->email_verified_at = Carbon::now();
     }
 }

--- a/app/Models/Observation.php
+++ b/app/Models/Observation.php
@@ -27,7 +27,8 @@ class Observation extends Model
     /**
      * @var array
      */
-    protected $fillable = ['participant_id', 'block_id', 'user_id', 'impression', 'content'];
+    protected $fillable = ['user_id', 'impression', 'content'];
+    protected $fillable_relations = ['block'];
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Models/Requirement.php
+++ b/app/Models/Requirement.php
@@ -54,7 +54,7 @@ class Requirement extends Model
      */
     public function blocks()
     {
-        return $this->belongsToMany('App\Models\Block');
+        return $this->belongsToMany('App\Models\Block', 'blocks_requirements', 'requirement_id', 'block_id');
     }
 
     /**

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\Validation\AllExistInCourse;
+use App\Services\Validation\ExistsInCourse;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\ServiceProvider;
+
+class ValidationServiceProvider extends ServiceProvider {
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register() {
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot() {
+        Validator::extend('existsInCourse', ExistsInCourse::class . '@validate');
+        Validator::extend('allExistInCourse', AllExistInCourse::class . '@validate');
+    }
+}

--- a/app/Services/Validation/AllExistInCourse.php
+++ b/app/Services/Validation/AllExistInCourse.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services\Validation;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Validator;
+
+class AllExistInCourse extends ExistsInCourse {
+
+    protected $delimiter;
+
+    public function __construct(Route $route, $delimiter = ',') {
+        parent::__construct($route);
+        $this->delimiter = $delimiter;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param mixed $value
+     * @param $parameters
+     * @param $validator Validator
+     * @return bool
+     */
+    public function validate($attribute, $value, $parameters, $validator) {
+
+        [$connection, $table, $column] = $this->getRelationTableAndColumn($attribute, $parameters, $validator);
+
+        $criteria = array_filter(explode($this->delimiter, $value));
+
+        return count($criteria) === DB::connection($connection)->table($table)
+                ->whereIn($column, $criteria)
+                ->where('course_id', $this->course->id)
+                ->distinct()
+                ->count($column);
+    }
+
+}

--- a/app/Services/Validation/ExistsInCourse.php
+++ b/app/Services/Validation/ExistsInCourse.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Validation;
+
+use App\Models\Model;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
+
+class ExistsInCourse {
+
+    protected $course;
+    protected $modelNamespace;
+
+    public function __construct(Route $route) {
+        $this->course = $route->parameter('course');
+        $this->modelNamespace = with(new \ReflectionClass(Model::class))->getNamespaceName();
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param $attribute
+     * @param mixed $value
+     * @param $parameters
+     * @param $validator Validator
+     * @return bool
+     */
+    public function validate($attribute, $value, $parameters, $validator) {
+
+        [$connection, $table, $column] = $this->getRelationTableAndColumn($attribute, $parameters, $validator);
+
+        return 1 === DB::connection($connection)->table($table)
+                ->where($column, $value)
+                ->where('course_id', $this->course->id)
+                ->count($column);
+    }
+
+    /**
+     * @param $attribute
+     * @param $parameters
+     * @param $validator Validator
+     * @return array
+     */
+    protected function getRelationTableAndColumn($attribute, $parameters, $validator) {
+
+        if (count($parameters) > 1) {
+            $column = $parameters[1];
+        } else {
+            $column = 'id';
+        }
+
+        if (count($parameters) > 0) {
+            [$connection, $table] = $validator->parseTable($parameters[0]);
+        } else {
+            $connection = null;
+            $model = $this->modelNamespace . '\\' . Str::singular(Str::studly($attribute));
+            $table = call_user_func($model . '::tableName');
+        }
+
+        return [$connection, $table, $column];
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "laravel/tinker": "^1.0",
     "phpoffice/phpspreadsheet": "^1.10",
     "sentry/sentry-laravel": "^1.7",
-    "tightenco/parental": "^0.8.0"
+    "tightenco/parental": "^0.8.0",
+    "troelskn/laravel-fillable-relations": "master"
   },
   "require-dev": {
     "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "254fa06eafbc15aaa93c0c3e8afe0641",
+    "content-hash": "de9b9746ce36f5d744928762d212b961",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -60,25 +60,25 @@
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
-            "version": "0.1",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
-                "reference": "265b8593498b997dc2d31e75b89f053b5cc9621a"
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/265b8593498b997dc2d31e75b89f053b5cc9621a",
-                "reference": "265b8593498b997dc2d31e75b89f053b5cc9621a",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "@stable"
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
             },
-            "type": "project",
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "XdgBaseDir\\": "src/"
@@ -89,20 +89,20 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24T07:27:01+00:00"
+            "time": "2019-12-04T15:06:13+00:00"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.8.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
-                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
-                "doctrine/coding-standard": "^4.0",
+                "doctrine/coding-standard": "^6.0",
                 "mongodb/mongodb": "^1.1",
                 "phpunit/phpunit": "^7.0",
                 "predis/predis": "~1.0"
@@ -124,7 +124,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.9.x-dev"
                 }
             },
             "autoload": {
@@ -138,16 +138,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -158,41 +158,47 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Caching library offering an object-oriented API for many cache backends",
-            "homepage": "https://www.doctrine-project.org",
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
             "keywords": [
+                "abstraction",
+                "apcu",
                 "cache",
-                "caching"
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
             ],
-            "time": "2018-08-21T18:01:43+00:00"
+            "time": "2019-11-29T15:36:20+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.9.2",
+            "version": "v2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9"
+                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
-                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
+                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.0",
                 "doctrine/event-manager": "^1.0",
                 "ext-pdo": "*",
-                "php": "^7.1"
+                "php": "^7.2"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "jetbrains/phpstorm-stubs": "^2018.1.2",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0",
-                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                "doctrine/coding-standard": "^6.0",
+                "jetbrains/phpstorm-stubs": "^2019.1",
+                "phpstan/phpstan": "^0.11.3",
+                "phpunit/phpunit": "^8.4.1",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -203,7 +209,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9.x-dev",
+                    "dev-master": "2.10.x-dev",
                     "dev-develop": "3.0.x-dev"
                 }
             },
@@ -218,16 +224,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -239,27 +245,38 @@
             "keywords": [
                 "abstraction",
                 "database",
+                "db2",
                 "dbal",
+                "mariadb",
+                "mssql",
                 "mysql",
-                "persistence",
+                "oci8",
+                "oracle",
+                "pdo",
                 "pgsql",
-                "php",
-                "queryobject"
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
             ],
-            "time": "2018-12-31T03:27:51+00:00"
+            "time": "2020-01-04T12:56:21+00:00"
         },
         {
             "name": "doctrine/event-manager",
-            "version": "v1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+                "reference": "629572819973f13486371cb611386eb17851e85c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
-                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/629572819973f13486371cb611386eb17851e85c",
+                "reference": "629572819973f13486371cb611386eb17851e85c",
                 "shasum": ""
             },
             "require": {
@@ -269,7 +286,7 @@
                 "doctrine/common": "<2.9@dev"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^4.0",
+                "doctrine/coding-standard": "^6.0",
                 "phpunit/phpunit": "^7.0"
             },
             "type": "library",
@@ -289,16 +306,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -313,27 +330,29 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Doctrine Event Manager component",
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
             "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
             "keywords": [
                 "event",
-                "eventdispatcher",
-                "eventmanager"
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
             ],
-            "time": "2018-06-11T11:59:03+00:00"
+            "time": "2019-11-10T09:48:07+00:00"
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
-                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
+                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
                 "shasum": ""
             },
             "require": {
@@ -359,16 +378,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -387,20 +406,20 @@
                 "singularize",
                 "string"
             ],
-            "time": "2018-01-09T20:05:19+00:00"
+            "time": "2019-10-30T19:59:35+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "e17f069ede36f7534b95adec71910ed1b49c74ea"
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e17f069ede36f7534b95adec71910ed1b49c74ea",
-                "reference": "e17f069ede36f7534b95adec71910ed1b49c74ea",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
                 "shasum": ""
             },
             "require": {
@@ -414,7 +433,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -449,7 +468,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-07-30T19:33:28+00:00"
+            "time": "2019-10-30T14:39:59+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -507,27 +526,27 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.11",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23"
+                "reference": "ade6887fd9bd74177769645ab5c474824f8a418a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/92dd169c32f6f55ba570c309d83f5209cefb5e23",
-                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/ade6887fd9bd74177769645ab5c474824f8a418a",
+                "reference": "ade6887fd9bd74177769645ab5c474824f8a418a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.5"
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.10"
             },
             "require-dev": {
-                "dominicsayers/isemail": "dev-master",
-                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
-                "satooshi/php-coveralls": "^1.0.1",
-                "symfony/phpunit-bridge": "^4.4@dev"
+                "dominicsayers/isemail": "^3.0.7",
+                "phpunit/phpunit": "^4.8.36|^7.5.15",
+                "satooshi/php-coveralls": "^1.0.1"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -561,20 +580,20 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-08-13T17:33:27+00:00"
+            "time": "2020-02-13T22:36:52+00:00"
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.7.3",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7"
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
-                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
                 "shasum": ""
             },
             "require": {
@@ -607,28 +626,28 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2019-03-17T18:48:37+00:00"
+            "time": "2019-12-30T22:54:17+00:00"
         },
         {
             "name": "fideloper/proxy",
-            "version": "4.2.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fideloper/TrustedProxy.git",
-                "reference": "03085e58ec7bee24773fa5a8850751a6e61a7e8a"
+                "reference": "ec38ad69ee378a1eec04fb0e417a97cfaf7ed11a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/03085e58ec7bee24773fa5a8850751a6e61a7e8a",
-                "reference": "03085e58ec7bee24773fa5a8850751a6e61a7e8a",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/ec38ad69ee378a1eec04fb0e417a97cfaf7ed11a",
+                "reference": "ec38ad69ee378a1eec04fb0e417a97cfaf7ed11a",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^5.0|^6.0|^7.0",
+                "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "illuminate/http": "^5.0|^6.0|^7.0",
+                "illuminate/http": "^5.0|^6.0|^7.0|^8.0",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.0"
             },
@@ -661,48 +680,50 @@
                 "proxy",
                 "trusted proxy"
             ],
-            "time": "2019-09-03T16:45:42+00:00"
+            "time": "2020-02-22T01:51:47+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.3.3",
+            "version": "6.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/43ece0e75098b7ecd8d13918293029e555a50f82",
+                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
+                "guzzlehttp/psr7": "^1.6.1",
                 "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1.1"
             },
             "suggest": {
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3-dev"
+                    "dev-master": "6.5-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -726,7 +747,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2018-04-22T15:46:56+00:00"
+            "time": "2019-12-23T11:57:10+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1041,16 +1062,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.8.35",
+            "version": "v5.8.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "5a9e4d241a8b815e16c9d2151e908992c38db197"
+                "reference": "ce08aaee3a0b8bb58b459b2decf7f25ba7b10fa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/5a9e4d241a8b815e16c9d2151e908992c38db197",
-                "reference": "5a9e4d241a8b815e16c9d2151e908992c38db197",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ce08aaee3a0b8bb58b459b2decf7f25ba7b10fa4",
+                "reference": "ce08aaee3a0b8bb58b459b2decf7f25ba7b10fa4",
                 "shasum": ""
             },
             "require": {
@@ -1185,20 +1206,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-09-03T16:44:30+00:00"
+            "time": "2020-02-14T14:29:11+00:00"
         },
         {
             "name": "laravel/socialite",
-            "version": "v4.2.0",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "f509d06e1e7323997b804c5152874f8aad4508e9"
+                "reference": "4bd66ee416fea04398dee5b8c32d65719a075db4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/f509d06e1e7323997b804c5152874f8aad4508e9",
-                "reference": "f509d06e1e7323997b804c5152874f8aad4508e9",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/4bd66ee416fea04398dee5b8c32d65719a075db4",
+                "reference": "4bd66ee416fea04398dee5b8c32d65719a075db4",
                 "shasum": ""
             },
             "require": {
@@ -1217,7 +1238,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -1249,7 +1270,7 @@
                 "laravel",
                 "oauth"
             ],
-            "time": "2019-09-03T15:27:17+00:00"
+            "time": "2020-02-04T15:30:01+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1316,16 +1337,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.55",
+            "version": "1.0.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "33c91155537c6dc899eacdc54a13ac6303f156e6"
+                "reference": "d13c43dbd4b791f815215959105a008515d1a2e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/33c91155537c6dc899eacdc54a13ac6303f156e6",
-                "reference": "33c91155537c6dc899eacdc54a13ac6303f156e6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/d13c43dbd4b791f815215959105a008515d1a2e0",
+                "reference": "d13c43dbd4b791f815215959105a008515d1a2e0",
                 "shasum": ""
             },
             "require": {
@@ -1337,7 +1358,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7.10"
+                "phpunit/phpunit": "^5.7.26"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -1396,7 +1417,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-08-24T11:17:19+00:00"
+            "time": "2020-02-05T18:14:17+00:00"
         },
         {
             "name": "league/oauth1-client",
@@ -1627,16 +1648,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.25.1",
+            "version": "1.25.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "70e65a5470a42cfec1a7da00d30edb6e617e8dcf"
+                "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/70e65a5470a42cfec1a7da00d30edb6e617e8dcf",
-                "reference": "70e65a5470a42cfec1a7da00d30edb6e617e8dcf",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fa82921994db851a8becaf3787a9e73c5976b6f1",
+                "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1",
                 "shasum": ""
             },
             "require": {
@@ -1701,31 +1722,31 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2019-09-06T13:49:17+00:00"
+            "time": "2019-12-20T14:15:16+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.24.0",
+            "version": "2.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "934459c5ac0658bc765ad1e53512c7c77adcac29"
+                "reference": "bbc0ab53f41a4c6f223c18efcdbd9bc725eb5d2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/934459c5ac0658bc765ad1e53512c7c77adcac29",
-                "reference": "934459c5ac0658bc765ad1e53512c7c77adcac29",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/bbc0ab53f41a4c6f223c18efcdbd9bc725eb5d2d",
+                "reference": "bbc0ab53f41a4c6f223c18efcdbd9bc725eb5d2d",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
-                "symfony/translation": "^3.4 || ^4.0"
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
                 "kylekatarnls/multi-tester": "^1.1",
-                "phpmd/phpmd": "dev-php-7.1-compatibility",
+                "phpmd/phpmd": "^2.8",
                 "phpstan/phpstan": "^0.11",
                 "phpunit/phpunit": "^7.5 || ^8.0",
                 "squizlabs/php_codesniffer": "^3.4"
@@ -1735,6 +1756,9 @@
             ],
             "type": "library",
             "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                },
                 "laravel": {
                     "providers": [
                         "Carbon\\Laravel\\ServiceProvider"
@@ -1761,27 +1785,27 @@
                     "homepage": "http://github.com/kylekatarnls"
                 }
             ],
-            "description": "A API extension for DateTime that supports 281 different languages.",
+            "description": "An API extension for DateTime that supports 281 different languages.",
             "homepage": "http://carbon.nesbot.com",
             "keywords": [
                 "date",
                 "datetime",
                 "time"
             ],
-            "time": "2019-08-31T16:37:55+00:00"
+            "time": "2020-03-01T11:11:58+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.4",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4"
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/97e59c7a16464196a8b9c77c47df68e4a39a45c4",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
                 "shasum": ""
             },
             "require": {
@@ -1789,6 +1813,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
+                "ircmaxell/php-yacc": "0.0.5",
                 "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
@@ -1797,7 +1822,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1819,7 +1844,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-09-01T07:51:21+00:00"
+            "time": "2019-11-08T13:50:10+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -1873,16 +1898,16 @@
         },
         {
             "name": "opis/closure",
-            "version": "3.4.0",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "60a97fff133b1669a5b1776aa8ab06db3f3962b7"
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/60a97fff133b1669a5b1776aa8ab06db3f3962b7",
-                "reference": "60a97fff133b1669a5b1776aa8ab06db3f3962b7",
+                "url": "https://api.github.com/repos/opis/closure/zipball/93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969",
                 "shasum": ""
             },
             "require": {
@@ -1895,7 +1920,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3.x-dev"
+                    "dev-master": "3.5.x-dev"
                 }
             },
             "autoload": {
@@ -1930,7 +1955,7 @@
                 "serialization",
                 "serialize"
             ],
-            "time": "2019-09-02T21:07:33+00:00"
+            "time": "2019-11-29T22:36:02+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2402,16 +2427,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.10.1",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "1648dc9ebef6ebe0c5a172e16cf66732918416e0"
+                "reference": "c2a205e82f9cf1cc9fab86b79e808d86dd680470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/1648dc9ebef6ebe0c5a172e16cf66732918416e0",
-                "reference": "1648dc9ebef6ebe0c5a172e16cf66732918416e0",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/c2a205e82f9cf1cc9fab86b79e808d86dd680470",
+                "reference": "c2a205e82f9cf1cc9fab86b79e808d86dd680470",
                 "shasum": ""
             },
             "require": {
@@ -2491,47 +2516,52 @@
                 "xls",
                 "xlsx"
             ],
-            "time": "2019-12-01T23:13:51+00:00"
+            "time": "2020-03-02T13:09:03+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.5.0",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed"
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/94e644f7d2051a5f0fcf77d81605f152eecff0ed",
-                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^5.5.9 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.7.*"
+                "bamarni/composer-bin-plugin": "^1.3",
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "PhpOption\\": "src/"
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache2"
+                "Apache-2.0"
             ],
             "authors": [
                 {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
                 }
             ],
             "description": "Option Type for PHP",
@@ -2541,7 +2571,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25T16:39:46+00:00"
+            "time": "2019-12-15T19:35:24+00:00"
         },
         {
             "name": "psr/container",
@@ -2745,16 +2775,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -2763,7 +2793,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -2788,7 +2818,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -2840,27 +2870,27 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.9",
+            "version": "v0.9.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "9aaf29575bb8293206bb0420c1e1c87ff2ffa94e"
+                "reference": "90da7f37568aee36b116a030c5f99c915267edd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/9aaf29575bb8293206bb0420c1e1c87ff2ffa94e",
-                "reference": "9aaf29575bb8293206bb0420c1e1c87ff2ffa94e",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/90da7f37568aee36b116a030c5f99c915267edd4",
+                "reference": "90da7f37568aee36b116a030c5f99c915267edd4",
                 "shasum": ""
             },
             "require": {
-                "dnoegel/php-xdg-base-dir": "0.1",
+                "dnoegel/php-xdg-base-dir": "0.1.*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*",
                 "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
                 "php": ">=5.4.0",
-                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
-                "symfony/var-dumper": "~2.7|~3.0|~4.0"
+                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0|~5.0",
+                "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
@@ -2910,7 +2940,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-10-13T15:16:03+00:00"
+            "time": "2019-12-06T14:19:43+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -2954,44 +2984,46 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.8.0",
+            "version": "3.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3"
+                "reference": "7e1633a6964b48589b142d60542f9ed31bd37a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/7e1633a6964b48589b142d60542f9ed31bd37a92",
+                "reference": "7e1633a6964b48589b142d60542f9ed31bd37a92",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "^1.0|^2.0|9.99.99",
-                "php": "^5.4 || ^7.0",
+                "ext-json": "*",
+                "paragonie/random_compat": "^1 | ^2 | 9.99.99",
+                "php": "^5.4 | ^7 | ^8",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^1.0 | ~2.0.0",
-                "doctrine/annotations": "~1.2.0",
-                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ~2.1.0",
-                "ircmaxell/random-lib": "^1.1",
-                "jakub-onderka/php-parallel-lint": "^0.9.0",
-                "mockery/mockery": "^0.9.9",
+                "codeception/aspect-mock": "^1 | ^2",
+                "doctrine/annotations": "^1.2",
+                "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
+                "jakub-onderka/php-parallel-lint": "^1",
+                "mockery/mockery": "^0.9.11 | ^1",
                 "moontoast/math": "^1.1",
-                "php-mock/php-mock-phpunit": "^0.3|^1.1",
-                "phpunit/phpunit": "^4.7|^5.0|^6.5",
-                "squizlabs/php_codesniffer": "^2.3"
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
+                "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
                 "ext-ctype": "Provides support for PHP Ctype functions",
                 "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
                 "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
-                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
@@ -3004,7 +3036,10 @@
             "autoload": {
                 "psr-4": {
                     "Ramsey\\Uuid\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3012,17 +3047,17 @@
             ],
             "authors": [
                 {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                },
+                {
                     "name": "Marijn Huizendveld",
                     "email": "marijn.huizendveld@gmail.com"
                 },
                 {
                     "name": "Thibaud Fabre",
                     "email": "thibaud@aztech.io"
-                },
-                {
-                    "name": "Ben Ramsey",
-                    "email": "ben@benramsey.com",
-                    "homepage": "https://benramsey.com"
                 }
             ],
             "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
@@ -3032,7 +3067,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2018-07-19T23:38:55+00:00"
+            "time": "2020-02-21T04:36:14+00:00"
         },
         {
             "name": "sentry/sdk",
@@ -3069,16 +3104,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "2.3.1",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "6d736f8cefa989f6171e30e1d1bfa214f7f5ab58"
+                "reference": "b3e71feb32f1787b66a3b4fdb8686972e9c7ba94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/6d736f8cefa989f6171e30e1d1bfa214f7f5ab58",
-                "reference": "6d736f8cefa989f6171e30e1d1bfa214f7f5ab58",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/b3e71feb32f1787b66a3b4fdb8686972e9c7ba94",
+                "reference": "b3e71feb32f1787b66a3b4fdb8686972e9c7ba94",
                 "shasum": ""
             },
             "require": {
@@ -3150,7 +3185,7 @@
                 "logging",
                 "sentry"
             ],
-            "time": "2020-01-23T09:40:22+00:00"
+            "time": "2020-03-06T09:24:53+00:00"
         },
         {
             "name": "sentry/sentry-laravel",
@@ -3223,16 +3258,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.2.1",
+            "version": "v6.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a"
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
-                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
                 "shasum": ""
             },
             "require": {
@@ -3281,31 +3316,32 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2019-04-21T09:21:45+00:00"
+            "time": "2019-11-12T09:31:26+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36"
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/de63799239b3881b8a08f8481b22348f77ed7b36",
-                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/service-contracts": "^1.1"
+                "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -3313,12 +3349,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/event-dispatcher": "^4.3",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/var-dumper": "^4.3"
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -3329,7 +3365,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3356,29 +3392,29 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T08:26:39+00:00"
+            "time": "2020-02-24T13:10:00+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.3.4",
+            "version": "v5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "c6e5e2a00db768c92c3ae131532af4e1acc7bd03"
+                "reference": "a0b51ba9938ccc206d9284de7eb527c2d4550b44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c6e5e2a00db768c92c3ae131532af4e1acc7bd03",
-                "reference": "c6e5e2a00db768c92c3ae131532af4e1acc7bd03",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/a0b51ba9938ccc206d9284de7eb527c2d4550b44",
+                "reference": "a0b51ba9938ccc206d9284de7eb527c2d4550b44",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3409,20 +3445,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-20T14:07:54+00:00"
+            "time": "2020-02-04T09:41:09+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "afcdea44a2e399c1e4b52246ec8d54c715393ced"
+                "reference": "a980d87a659648980d89193fd8b7a7ca89d97d21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/afcdea44a2e399c1e4b52246ec8d54c715393ced",
-                "reference": "afcdea44a2e399c1e4b52246ec8d54c715393ced",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/a980d87a659648980d89193fd8b7a7ca89d97d21",
+                "reference": "a980d87a659648980d89193fd8b7a7ca89d97d21",
                 "shasum": ""
             },
             "require": {
@@ -3433,12 +3469,12 @@
                 "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~3.4|~4.0"
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3465,20 +3501,76 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-20T14:27:59+00:00"
+            "time": "2020-02-23T14:41:43+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v4.3.4",
+            "name": "symfony/error-handler",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2"
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "89aa4b9ac6f1f35171b8621b24f60477312085be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
-                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/89aa4b9ac6f1f35171b8621b24f60477312085be",
+                "reference": "89aa4b9ac6f1f35171b8621b24f60477312085be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0",
+                "symfony/debug": "^4.4.5",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ErrorHandler Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-02-26T11:45:31+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "4ad8e149799d3128621a3a1f70e92b9897a8930d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4ad8e149799d3128621a3a1f70e92b9897a8930d",
+                "reference": "4ad8e149799d3128621a3a1f70e92b9897a8930d",
                 "shasum": ""
             },
             "require": {
@@ -3494,12 +3586,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "^3.4|^4.0",
-                "symfony/service-contracts": "^1.1",
-                "symfony/stopwatch": "~3.4|~4.0"
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -3508,7 +3600,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3535,20 +3627,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T08:55:16+00:00"
+            "time": "2020-02-04T09:32:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v1.1.5",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c"
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c61766f4440ca687de1084a5c00b08e167a2575c",
-                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
                 "shasum": ""
             },
             "require": {
@@ -3593,20 +3685,20 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-06-20T06:46:26+00:00"
+            "time": "2019-09-17T09:54:03+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2"
+                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
-                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
+                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
                 "shasum": ""
             },
             "require": {
@@ -3615,7 +3707,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3642,20 +3734,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-14T12:26:46+00:00"
+            "time": "2020-02-14T07:42:58+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.1",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8bccc59e61b41963d14c3dbdb23181e5c932a1d5"
+                "reference": "7e41b4fcad4619535f45f8bfa7744c4f384e1648"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8bccc59e61b41963d14c3dbdb23181e5c932a1d5",
-                "reference": "8bccc59e61b41963d14c3dbdb23181e5c932a1d5",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7e41b4fcad4619535f45f8bfa7744c4f384e1648",
+                "reference": "7e41b4fcad4619535f45f8bfa7744c4f384e1648",
                 "shasum": ""
             },
             "require": {
@@ -3697,37 +3789,37 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-28T13:33:56+00:00"
+            "time": "2020-02-13T19:40:01+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "5e0fc71be03d52cd00c423061cfd300bd6f92a52"
+                "reference": "8c8734486dada83a6041ab744709bdc1651a8462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/5e0fc71be03d52cd00c423061cfd300bd6f92a52",
-                "reference": "5e0fc71be03d52cd00c423061cfd300bd6f92a52",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8c8734486dada83a6041ab744709bdc1651a8462",
+                "reference": "8c8734486dada83a6041ab744709bdc1651a8462",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/debug": "~3.4|~4.0",
-                "symfony/event-dispatcher": "^4.3",
-                "symfony/http-foundation": "^4.1.1",
-                "symfony/polyfill-ctype": "~1.8",
+                "symfony/error-handler": "^4.4",
+                "symfony/event-dispatcher": "^4.4",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
                 "symfony/browser-kit": "<4.3",
                 "symfony/config": "<3.4",
+                "symfony/console": ">=5",
                 "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
-                "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
             },
             "provide": {
@@ -3735,34 +3827,32 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "^4.3",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dependency-injection": "^4.3",
-                "symfony/dom-crawler": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/finder": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/routing": "~3.4|~4.0",
-                "symfony/stopwatch": "~3.4|~4.0",
-                "symfony/templating": "~3.4|~4.0",
-                "symfony/translation": "~4.2",
-                "symfony/translation-contracts": "^1.1",
-                "symfony/var-dumper": "^4.1.1",
-                "twig/twig": "^1.34|^2.4"
+                "symfony/browser-kit": "^4.3|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0",
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/routing": "^3.4|^4.0|^5.0",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0",
+                "symfony/templating": "^3.4|^4.0|^5.0",
+                "symfony/translation": "^4.2|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "twig/twig": "^1.34|^2.4|^3.0"
             },
             "suggest": {
                 "symfony/browser-kit": "",
                 "symfony/config": "",
                 "symfony/console": "",
-                "symfony/dependency-injection": "",
-                "symfony/var-dumper": ""
+                "symfony/dependency-injection": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3789,24 +3879,24 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T16:47:42+00:00"
+            "time": "2020-02-29T10:31:38+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v4.4.1",
+            "version": "v5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "010cc488e56cafe5f7494dea70aea93100c234df"
+                "reference": "9b3e5b5e58c56bbd76628c952d2b78556d305f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/010cc488e56cafe5f7494dea70aea93100c234df",
-                "reference": "010cc488e56cafe5f7494dea70aea93100c234df",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/9b3e5b5e58c56bbd76628c952d2b78556d305f3c",
+                "reference": "9b3e5b5e58c56bbd76628c952d2b78556d305f3c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
@@ -3815,12 +3905,12 @@
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10",
-                "symfony/dependency-injection": "^3.4|^4.1|^5.0"
+                "symfony/dependency-injection": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3851,7 +3941,7 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2019-11-30T08:27:26+00:00"
+            "time": "2020-02-04T09:41:09+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3909,16 +3999,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -3930,7 +4020,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -3963,20 +4053,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.12.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f"
+                "reference": "926832ce51059bb58211b7b2080a88e0c3b5328e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/685968b11e61a347c18bf25db32effa478be610f",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/926832ce51059bb58211b7b2080a88e0c3b5328e",
+                "reference": "926832ce51059bb58211b7b2080a88e0c3b5328e",
                 "shasum": ""
             },
             "require": {
@@ -3988,7 +4078,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -4022,26 +4112,26 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46"
+                "reference": "6842f1a39cf7d580655688069a03dd7cd83d244a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
-                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6842f1a39cf7d580655688069a03dd7cd83d244a",
+                "reference": "6842f1a39cf7d580655688069a03dd7cd83d244a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php72": "^1.9"
+                "symfony/polyfill-php72": "^1.10"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -4049,7 +4139,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -4084,20 +4174,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-17T12:01:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
                 "shasum": ""
             },
             "require": {
@@ -4109,7 +4199,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -4143,20 +4233,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T14:18:11+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038"
+                "reference": "46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/66fea50f6cb37a35eea048d75a7d99a45b586038",
-                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf",
+                "reference": "46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf",
                 "shasum": ""
             },
             "require": {
@@ -4165,7 +4255,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -4198,20 +4288,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.12.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
                 "shasum": ""
             },
             "require": {
@@ -4220,7 +4310,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -4256,7 +4346,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -4319,16 +4409,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a"
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e89969c00d762349f078db1128506f7f3dcc0d4a",
-                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
                 "shasum": ""
             },
             "require": {
@@ -4337,7 +4427,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4364,20 +4454,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T08:26:39+00:00"
+            "time": "2020-02-07T20:06:44+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "ff1049f6232dc5b6023b1ff1c6de56f82bcd264f"
+                "reference": "4124d621d0e445732520037f888a0456951bde8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/ff1049f6232dc5b6023b1ff1c6de56f82bcd264f",
-                "reference": "ff1049f6232dc5b6023b1ff1c6de56f82bcd264f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/4124d621d0e445732520037f888a0456951bde8c",
+                "reference": "4124d621d0e445732520037f888a0456951bde8c",
                 "shasum": ""
             },
             "require": {
@@ -4391,11 +4481,11 @@
             "require-dev": {
                 "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
-                "symfony/config": "~4.2",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/config": "^4.2|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
@@ -4407,7 +4497,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4440,24 +4530,24 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-08-26T08:26:39+00:00"
+            "time": "2020-02-25T12:41:09+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.6",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -4466,7 +4556,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4498,30 +4588,31 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-08-20T14:44:19+00:00"
+            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "28498169dd334095fa981827992f3a24d50fed0f"
+                "reference": "0a19a77fba20818a969ef03fdaf1602de0546353"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/28498169dd334095fa981827992f3a24d50fed0f",
-                "reference": "28498169dd334095fa981827992f3a24d50fed0f",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/0a19a77fba20818a969ef03fdaf1602de0546353",
+                "reference": "0a19a77fba20818a969ef03fdaf1602de0546353",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^1.1.6"
+                "symfony/translation-contracts": "^1.1.6|^2"
             },
             "conflict": {
                 "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<4.4",
                 "symfony/yaml": "<3.4"
             },
             "provide": {
@@ -4529,15 +4620,14 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/intl": "~3.4|~4.0",
-                "symfony/service-contracts": "^1.1.2",
-                "symfony/var-dumper": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/finder": "~2.8|~3.0|~4.0|^5.0",
+                "symfony/http-kernel": "^4.4",
+                "symfony/intl": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -4547,7 +4637,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4574,24 +4664,24 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T08:55:16+00:00"
+            "time": "2020-02-04T09:32:40+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v1.1.6",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "325b17c24f3ee23cbecfa63ba809c6d89b5fa04a"
+                "reference": "8cc682ac458d75557203b2f2f14b0b92e1c744ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/325b17c24f3ee23cbecfa63ba809c6d89b5fa04a",
-                "reference": "325b17c24f3ee23cbecfa63ba809c6d89b5fa04a",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/8cc682ac458d75557203b2f2f14b0b92e1c744ed",
+                "reference": "8cc682ac458d75557203b2f2f14b0b92e1c744ed",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "suggest": {
                 "symfony/translation-implementation": ""
@@ -4599,7 +4689,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4631,20 +4721,20 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-08-02T12:15:04+00:00"
+            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "641043e0f3e615990a0f29479f9c117e8a6698c6"
+                "reference": "2572839911702b0405479410ea7a1334bfab0b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/641043e0f3e615990a0f29479f9c117e8a6698c6",
-                "reference": "641043e0f3e615990a0f29479f9c117e8a6698c6",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2572839911702b0405479410ea7a1334bfab0b96",
+                "reference": "2572839911702b0405479410ea7a1334bfab0b96",
                 "shasum": ""
             },
             "require": {
@@ -4658,9 +4748,9 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^1.34|^2.4|^3.0"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
@@ -4673,7 +4763,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4707,7 +4797,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-08-26T08:26:39+00:00"
+            "time": "2020-02-24T13:10:00+00:00"
         },
         {
             "name": "tightenco/parental",
@@ -4752,21 +4842,23 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757"
+                "reference": "dda2ee426acd6d801d5b7fd1001cde9b5f790e15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
-                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/dda2ee426acd6d801d5b7fd1001cde9b5f790e15",
+                "reference": "dda2ee426acd6d801d5b7fd1001cde9b5f790e15",
                 "shasum": ""
             },
             "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
                 "php": "^5.5 || ^7.0",
-                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0"
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
@@ -4795,20 +4887,62 @@
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "time": "2017-11-27T11:13:29+00:00"
+            "time": "2019-10-24T08:53:34+00:00"
         },
         {
-            "name": "vlucas/phpdotenv",
-            "version": "v3.5.0",
+            "name": "troelskn/laravel-fillable-relations",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "95cb0fa6c025f7f0db7fc60f81e9fb231eb2d222"
+                "url": "https://github.com/troelskn/laravel-fillable-relations.git",
+                "reference": "7b60422865650052d013fad741a8aef9078b5a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/95cb0fa6c025f7f0db7fc60f81e9fb231eb2d222",
-                "reference": "95cb0fa6c025f7f0db7fc60f81e9fb231eb2d222",
+                "url": "https://api.github.com/repos/troelskn/laravel-fillable-relations/zipball/7b60422865650052d013fad741a8aef9078b5a95",
+                "reference": "7b60422865650052d013fad741a8aef9078b5a95",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": ">=5.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "orchestra/database": "3.3.1",
+                "orchestra/testbench": "3.3",
+                "phpunit/phpunit": "~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LaravelFillableRelations\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Troels Knak-Nielsen",
+                    "email": "troelskn@gmail.com"
+                }
+            ],
+            "description": "Provides HasFillableRelations trait to Eloquent models",
+            "time": "2019-12-03T12:36:57+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "1bdf24f065975594f6a117f0f1f6cabf1333b156"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1bdf24f065975594f6a117f0f1f6cabf1333b156",
+                "reference": "1bdf24f065975594f6a117f0f1f6cabf1333b156",
                 "shasum": ""
             },
             "require": {
@@ -4817,12 +4951,12 @@
                 "symfony/polyfill-ctype": "^1.9"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.5-dev"
+                    "dev-master": "3.6-dev"
                 }
             },
             "autoload": {
@@ -4852,7 +4986,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-08-27T17:00:38+00:00"
+            "time": "2019-09-10T21:37:39+00:00"
         }
     ],
     "packages-dev": [
@@ -4919,16 +5053,16 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -4971,20 +5105,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "filp/whoops",
-            "version": "2.5.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "cde50e6720a39fdacb240159d3eea6865d51fd96"
+                "reference": "fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/cde50e6720a39fdacb240159d3eea6865d51fd96",
-                "reference": "cde50e6720a39fdacb240159d3eea6865d51fd96",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130",
+                "reference": "fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130",
                 "shasum": ""
             },
             "require": {
@@ -4993,8 +5127,8 @@
             },
             "require-dev": {
                 "mockery/mockery": "^0.9 || ^1.0",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0",
+                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -5003,7 +5137,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -5032,20 +5166,20 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2019-08-07T09:00:00+00:00"
+            "time": "2020-01-15T10:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.8.0",
+            "version": "v1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de"
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/f72816b43e74063c8b10357394b6bba8cb1c10de",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f",
                 "shasum": ""
             },
             "require": {
@@ -5054,12 +5188,12 @@
             "require-dev": {
                 "ext-intl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "squizlabs/php_codesniffer": "^1.5"
+                "squizlabs/php_codesniffer": "^2.9.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -5082,7 +5216,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2018-07-12T10:23:15+00:00"
+            "time": "2019-12-12T13:22:17+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -5134,16 +5268,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "4eff936d83eb809bde2c57a3cea0ee9643769031"
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/4eff936d83eb809bde2c57a3cea0ee9643769031",
-                "reference": "4eff936d83eb809bde2c57a3cea0ee9643769031",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
                 "shasum": ""
             },
             "require": {
@@ -5157,7 +5291,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -5195,20 +5329,20 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-08-07T15:01:07+00:00"
+            "time": "2019-12-26T09:49:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.3",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -5243,7 +5377,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-08-09T12:45:53+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -5413,35 +5547,33 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5463,44 +5595,42 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5511,44 +5641,46 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2020-02-22T12:28:44+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5561,37 +5693,38 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -5624,7 +5757,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5831,16 +5964,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
-                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
@@ -5876,20 +6009,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-07-25T05:29:42+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.15",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d79c053d972856b8b941bb233e39dc521a5093f0"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d79c053d972856b8b941bb233e39dc521a5093f0",
-                "reference": "d79c053d972856b8b941bb233e39dc521a5093f0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
@@ -5960,7 +6093,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-08-21T07:05:16+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -6129,16 +6262,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.2",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
@@ -6178,20 +6311,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-05-05T09:05:15+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/06a9a5947f47b3029d76118eb5c22802e5869687",
-                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
@@ -6245,7 +6378,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-08-11T12:43:14+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -6530,16 +6663,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.3.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "cc686552948d627528c0e2e759186dff67c2610e"
+                "reference": "11dcf08f12f29981bf770f097a5d64d65bce5929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/cc686552948d627528c0e2e759186dff67c2610e",
-                "reference": "cc686552948d627528c0e2e759186dff67c2610e",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/11dcf08f12f29981bf770f097a5d64d65bce5929",
+                "reference": "11dcf08f12f29981bf770f097a5d64d65bce5929",
                 "shasum": ""
             },
             "require": {
@@ -6552,7 +6685,7 @@
             },
             "require-dev": {
                 "masterminds/html5": "^2.6",
-                "symfony/css-selector": "~3.4|~4.0"
+                "symfony/css-selector": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -6560,7 +6693,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -6587,7 +6720,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T08:26:39+00:00"
+            "time": "2020-02-29T10:05:28+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -6631,31 +6764,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -6677,7 +6808,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2020-02-14T12:15:55+00:00"
         }
     ],
     "aliases": [],

--- a/config/app.php
+++ b/config/app.php
@@ -188,6 +188,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\ImportServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\ValidationServiceProvider::class,
 
     ],
 

--- a/resources/lang/de/t.php
+++ b/resources/lang/de/t.php
@@ -60,6 +60,9 @@ return array(
 		"invitation" => array(
 			"email" => "E-Mail",
 		),
+		"invitation_claim" => array(
+		    "token" => "Token",
+		),
 		"observation" => array(
 			"block" => "Block",
 			"categories" => "Kategorien",

--- a/resources/lang/de/t.php
+++ b/resources/lang/de/t.php
@@ -79,6 +79,7 @@ return array(
 			"scout_name" => "Pfadiname",
 		),
 		"requirement" => array(
+			"blocks" => "Blöcke",
 			"content" => "Anforderung",
 			"mandatory" => "Mindestanforderung",
 			"num_observations" => "Anzahl Beobachtungen",

--- a/resources/lang/de/validation.php
+++ b/resources/lang/de/validation.php
@@ -4,6 +4,7 @@ return array(
 	"active_url" => ":attribute ist keine gültige Internet-Adresse.",
 	"after" => ":attribute muss ein Datum nach dem :date sein.",
 	"after_or_equal" => ":attribute muss ein Datum nach dem :date oder gleich dem :date sein.",
+	"all_exist_in_course" => "Der gewählte Wert für :attribute ist ungültig.",
 	"alpha" => ":attribute darf nur aus Buchstaben bestehen.",
 	"alpha_dash" => ":attribute darf nur aus Buchstaben, Zahlen, Binde- und Unterstrichen bestehen.",
 	"alpha_num" => ":attribute darf nur aus Buchstaben und Zahlen bestehen.",
@@ -65,6 +66,7 @@ return array(
 	"email" => ":attribute muss eine gültige E-Mail-Adresse sein.",
 	"ends_with" => ":attribute muss auf einen der folgenden Werte enden: :values",
 	"exists" => "Der gewählte Wert für :attribute ist ungültig.",
+	"exists_in_course" => "Der gewählte Wert für :attribute ist ungültig.",
 	"file" => ":attribute muss eine Datei sein.",
 	"filled" => ":attribute muss ausgefüllt sein.",
 	"gt" => array(

--- a/resources/lang/fr/t.php
+++ b/resources/lang/fr/t.php
@@ -60,6 +60,9 @@ return array(
 		"invitation" => array(
 			"email" => "E-mail",
 		),
+		"invitation_claim" => array(
+			"token" => "Token"
+		),
 		"observation" => array(
 			"block" => "Point de cours",
 			"categories" => "Catégories",

--- a/resources/lang/fr/t.php
+++ b/resources/lang/fr/t.php
@@ -79,6 +79,7 @@ return array(
 			"scout_name" => "Nom",
 		),
 		"requirement" => array(
+			"blocks" => "Points de cours",
 			"content" => "Exigence",
 			"mandatory" => "Éliminatoire",
 			"num_observations" => "Nombre d'observations",

--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -7,6 +7,7 @@ return array(
 	"alpha" => "Le champ :attribute doit contenir uniquement des lettres.",
 	"alpha_dash" => "Le champ :attribute doit contenir uniquement des lettres, des chiffres et des tirets.",
 	"alpha_num" => "Le champ :attribute doit contenir uniquement des chiffres et des lettres.",
+	"all_exist_in_course" => "Le champ :attribute sélectionné est invalide.",
 	"array" => "Le champ :attribute doit être un tableau.",
 	"attributes" => array(
 		"address" => "adresse",
@@ -65,6 +66,7 @@ return array(
 	"email" => "Le champ :attribute doit être une adresse email valide.",
 	"ends_with" => "Le champ :attribute doit se terminer par une des valeurs suivantes : :values",
 	"exists" => "Le champ :attribute sélectionné est invalide.",
+	"exists_in_course" => "Le champ :attribute sélectionné est invalide.",
 	"file" => "Le champ :attribute doit être un fichier.",
 	"filled" => "Le champ :attribute doit avoir une valeur.",
 	"gt" => array(

--- a/resources/views/admin/blocks/edit.blade.php
+++ b/resources/views/admin/blocks/edit.blade.php
@@ -13,7 +13,7 @@
             @component('components.form.dateInput', ['name' => 'block_date', 'label' => __('t.models.block.block_date'), 'required' => true, 'value' => $block->block_date])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'requirement_ids',
+                'name' => 'requirements',
                 'label' => __('t.models.block.requirements'),
                 'value' => implode(',', array_map(function(\App\Models\Requirement $requirement) { return $requirement->id; }, $block->requirements->all())),
                 'options' => $course->requirements->all(),

--- a/resources/views/admin/blocks/index.blade.php
+++ b/resources/views/admin/blocks/index.blade.php
@@ -13,7 +13,7 @@
             @component('components.form.dateInput', ['name' => 'block_date', 'label' => __('t.models.block.block_date'), 'required' => true, 'value' => Auth::user()->getLastUsedBlockDate($course)])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'requirement_ids',
+                'name' => 'requirements',
                 'label' => __('t.models.block.requirements'),
                 'options' => $course->requirements->all(),
                 'valueFn' => function(\App\Models\Requirement $requirement) { return $requirement->id; },

--- a/resources/views/admin/requirements/edit.blade.php
+++ b/resources/views/admin/requirements/edit.blade.php
@@ -10,6 +10,16 @@
 
             @component('components.form.checkboxInput', ['name' => 'mandatory', 'label' => __('t.models.requirement.mandatory'), 'value' => $requirement->mandatory])@endcomponent
 
+            @component('components.form.multiSelectInput', [
+                'name' => 'blocks',
+                'label' => __('t.models.requirement.blocks'),
+                'value' => implode(',', array_map(function(\App\Models\Block $block) { return $block->id; }, $requirement->blocks->all())),
+                'options' => $course->blocks->all(),
+                'valueFn' => function(\App\Models\Block $block) { return $block->id; },
+                'displayFn' => function(\App\Models\Block $block) { return $block->name; },
+                'multiple' => true,
+            ])@endcomponent
+
             @component('components.form.submit', ['label' => __('t.global.save')])@endcomponent
 
         @endcomponent

--- a/resources/views/admin/requirements/index.blade.php
+++ b/resources/views/admin/requirements/index.blade.php
@@ -10,6 +10,15 @@
 
             @component('components.form.checkboxInput', ['name' => 'mandatory', 'label' => __('t.models.requirement.mandatory')])@endcomponent
 
+            @component('components.form.multiSelectInput', [
+                'name' => 'blocks',
+                'label' => __('t.models.requirement.blocks'),
+                'options' => $course->blocks->all(),
+                'valueFn' => function(\App\Models\Block $block) { return $block->id; },
+                'displayFn' => function(\App\Models\Block $block) { return $block->name; },
+                'multiple' => true,
+            ])@endcomponent
+
             @component('components.form.submit', ['label' => __('t.global.add')])
 
                 @component('components.help-text', ['id' => 'requirementsHelp', 'key' => 't.views.admin.requirements.what_are_requirements'])@endcomponent

--- a/resources/views/includes/header.blade.php
+++ b/resources/views/includes/header.blade.php
@@ -47,16 +47,16 @@
                                href="{{ route('admin.course', ['course' => $course->id]) }}">{{__('t.views.admin.course_settings.menu_name')}}</a>
                             <a class="dropdown-item{{ Route::currentRouteName() == 'admin.equipe' ? ' active' : '' }}"
                                href="{{ route('admin.equipe', ['course' => $course->id]) }}">{{__('t.views.admin.equipe.menu_name')}}</a>
-                            <a class="dropdown-item{{ Route::currentRouteName() == 'admin.requirements' ? ' active' : '' }}"
-                               href="{{ route('admin.requirements', ['course' => $course->id]) }}">{{__('t.views.admin.requirements.menu_name')}}</a>
-                            <a class="dropdown-item{{ Route::currentRouteName() == 'admin.categories' ? ' active' : '' }}"
-                               href="{{ route('admin.categories', ['course' => $course->id]) }}">{{__('t.views.admin.categories.menu_name')}}</a>
                             <a class="dropdown-item{{ Route::currentRouteName() == 'admin.blocks' ? ' active' : '' }}"
                                href="{{ route('admin.blocks', ['course' => $course->id]) }}">{{__('t.views.admin.blocks.menu_name')}}</a>
                             @if(!$course->archived)
                                 <a class="dropdown-item{{ Route::currentRouteName() == 'admin.participants' ? ' active' : '' }}"
                                    href="{{ route('admin.participants', ['course' => $course->id]) }}">{{__('t.views.admin.participants.menu_name')}}</a>
                             @endif
+                            <a class="dropdown-item{{ Route::currentRouteName() == 'admin.requirements' ? ' active' : '' }}"
+                               href="{{ route('admin.requirements', ['course' => $course->id]) }}">{{__('t.views.admin.requirements.menu_name')}}</a>
+                            <a class="dropdown-item{{ Route::currentRouteName() == 'admin.categories' ? ' active' : '' }}"
+                               href="{{ route('admin.categories', ['course' => $course->id]) }}">{{__('t.views.admin.categories.menu_name')}}</a>
                         </div>
                     </li>
                 @endif

--- a/resources/views/observation/edit.blade.php
+++ b/resources/views/observation/edit.blade.php
@@ -7,7 +7,7 @@
         @component('components.form', ['route' => ['observation.update', ['course' => $course->id, 'observation' => $observation->id]]])
 
             @component('components.form.multiSelectInput', [
-                'name' => 'participant_ids',
+                'name' => 'participants',
                 'label' => __('t.models.observation.participants'),
                 'required' => true,
                 'value' => implode(',', array_map(function (\App\Models\Participant $participant) { return $participant->id; }, $observation->participants->all())),
@@ -20,7 +20,7 @@
             @component('components.form.textareaInput', ['name' => 'content', 'label' => __('t.models.observation.content'), 'required' => true, 'autofocus' => true, 'value' => $observation->content])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'block_id',
+                'name' => 'block',
                 'label' => __('t.models.observation.block'),
                 'required' => true,
                 'value' => $observation->block->id,
@@ -32,7 +32,7 @@
             ])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'requirement_ids',
+                'name' => 'requirements',
                 'label' => __('t.models.observation.requirements'),
                 'value' => implode(',', array_map(function (\App\Models\Requirement $requirement) { return $requirement->id; }, $observation->requirements->all())),
                 'options' => $course->requirements->all(),
@@ -50,7 +50,7 @@
             ])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'category_ids',
+                'name' => 'categories',
                 'label' => __('t.models.observation.categories'),
                 'options' => $course->categories->all(),
                 'value' => implode(',', array_map(function (\App\Models\Category $category) { return $category->id; }, $observation->categories->all())),

--- a/resources/views/observation/new.blade.php
+++ b/resources/views/observation/new.blade.php
@@ -7,26 +7,26 @@
         @component('components.form', ['route' => ['observation.store', ['course' => $course->id]]])
 
             @component('components.form.multiSelectInput', [
-                'name' => 'participant_ids',
+                'name' => 'participants',
                 'label' => __('t.models.observation.participants'),
                 'required' => true,
-                'value' => $participant_id,
+                'value' => $participants,
                 'options' => $course->participants->all(),
                 'valueFn' => function(\App\Models\Participant $participant) { return $participant->id; },
                 'displayFn' => function(\App\Models\Participant $participant) { return $participant->scout_name; },
                 'multiple' => true,
-                'autofocus' => ($participant_id === null)
+                'autofocus' => ($participants === null)
             ])@endcomponent
 
-            @component('components.form.textareaInput', ['name' => 'content', 'label' => __('t.models.observation.content'), 'required' => true, 'autofocus' => ($participant_id !== null)])@endcomponent
+            @component('components.form.textareaInput', ['name' => 'content', 'label' => __('t.models.observation.content'), 'required' => true, 'autofocus' => ($participants !== null)])@endcomponent
 
-            <block-and-requirements-input-wrapper v-slot="slotProps" @if(old('requirement_ids', 'OBSERVATION_NO_OLD_VALUES') !== 'OBSERVATION_NO_OLD_VALUES') :has-old-values="true" @endif>
+            <block-and-requirements-input-wrapper v-slot="slotProps" @if(old('requirements', 'OBSERVATION_NO_OLD_VALUES') !== 'OBSERVATION_NO_OLD_VALUES') :has-old-values="true" @endif>
 
                 @component('components.form.multiSelectInput', [
-                    'name' => 'block_id',
+                    'name' => 'block',
                     'label' => __('t.models.observation.block'),
                     'required' => true,
-                    'value' => $block_id,
+                    'value' => $block,
                     'options' => $course->blocks->all(),
                     'valueFn' => function(\App\Models\Block $block) { return $block->id; },
                     'displayFn' => function(\App\Models\Block $block) { return $block->blockname_and_number; },
@@ -36,7 +36,7 @@
                 ])@endcomponent
 
                 @component('components.form.multiSelectInput', [
-                    'name' => 'requirement_ids',
+                    'name' => 'requirements',
                     'label' => __('t.models.observation.requirements'),
                     'valueBind' => 'slotProps.requirementsValue',
                     'options' => $course->requirements->all(),
@@ -56,7 +56,7 @@
             ])@endcomponent
 
             @component('components.form.multiSelectInput', [
-                'name' => 'category_ids',
+                'name' => 'categories',
                 'label' => __('t.models.observation.categories'),
                 'options' => $course->categories->all(),
                 'valueFn' => function(\App\Models\Category $category) { return $category->id; },

--- a/tests/Feature/Admin/Block/CreateBlockTest.php
+++ b/tests/Feature/Admin/Block/CreateBlockTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin\Block;
 
+use App\Models\Block;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Validation\ValidationException;
@@ -55,6 +56,9 @@ class CreateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blocknummer Format ist ungültig.', $exception->validator->errors()->first('full_block_number'));
     }
 
     public function test_shouldValidateNewBlockData_noBlockname() {
@@ -67,6 +71,9 @@ class CreateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blockname muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewBlockData_longBlockname() {
@@ -79,6 +86,9 @@ class CreateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blockname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewBlockData_noDatum() {
@@ -91,6 +101,9 @@ class CreateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Datum muss ausgefüllt sein.', $exception->validator->errors()->first('block_date'));
     }
 
     public function test_shouldValidateNewBlockData_invalidDatum() {
@@ -103,6 +116,100 @@ class CreateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Datum muss ein gültiges Datum sein.', $exception->validator->errors()->first('block_date'));
+    }
+
+    public function test_shouldValidateNewBlockData_noRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $payload['requirements'] = null;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals([], Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_invalidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $payload['requirements'] = 'xyz';
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderungen Format ist ungültig.', $exception->validator->errors()->first('requirements'));
+    }
+
+    public function test_shouldValidateNewBlockData_oneValidRequirementId() {
+        // given
+        $payload = $this->payload;
+        $requirementId = $this->createRequirement();
+        $payload['requirements'] = $requirementId;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals([$requirementId], Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_multipleValidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals($requirementIds, Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_someNonexistentRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), '999999', $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirements'));
+    }
+
+    public function test_shouldValidateNewBlockData_someInvalidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), 'abc', $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks', $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderungen Format ist ungültig.', $exception->validator->errors()->first('requirements'));
     }
 
     public function test_shouldShowMessage_whenNoBlocksInCourse() {

--- a/tests/Feature/Admin/Block/CreateBlockTest.php
+++ b/tests/Feature/Admin/Block/CreateBlockTest.php
@@ -14,7 +14,7 @@ class CreateBlockTest extends TestCaseWithCourse {
     public function setUp(): void {
         parent::setUp();
 
-        $this->payload = ['full_block_number' => '1.1', 'name' => 'Block 1', 'block_date' => '01.01.2019', 'requirement_ids' => null];
+        $this->payload = ['full_block_number' => '1.1', 'name' => 'Block 1', 'block_date' => '01.01.2019', 'requirements' => null];
     }
 
     public function test_shouldRequireLogin() {

--- a/tests/Feature/Admin/Block/ImportBlocksTest.php
+++ b/tests/Feature/Admin/Block/ImportBlocksTest.php
@@ -108,7 +108,7 @@ class ImportBlocksTest extends TestCaseWithCourse {
         // given
         $blockId = $this->createBlock('Existierender Block', '1.1', '09.09.2009');
         $participantId = $this->createParticipant('Pflock');
-        $existingObservationId = Observation::create(['user_id' => $this->user()->id, 'block_id' => $blockId, 'content' => 'something', 'impression' => 0, 'participant_ids' => [$participantId]])->id;
+        $existingObservationId = Observation::create(['user_id' => $this->user()->id, 'block' => $blockId, 'content' => 'something', 'impression' => 0, 'participants' => [$participantId]])->id;
         $this->setUpInputFile('Blockuebersicht.xls');
 
         // when

--- a/tests/Feature/Admin/Block/ReadBlockTest.php
+++ b/tests/Feature/Admin/Block/ReadBlockTest.php
@@ -53,7 +53,7 @@ class ReadBlockTest extends TestCaseWithCourse {
     public function test_shouldNotDisplayBlock_fromOtherUser() {
         // given
         $otherKursId = $this->createCourse('Zweiter Kurs', '', false);
-        $otherBlockId = Block::create(['course_id' => $otherKursId, 'full_block_number' => '1.1', 'name' => 'later date', 'block_date' => '02.01.2019', 'requirement_ids' => null])->id;
+        $otherBlockId = Block::create(['course_id' => $otherKursId, 'full_block_number' => '1.1', 'name' => 'later date', 'block_date' => '02.01.2019', 'requirements' => null])->id;
 
         // when
         $response = $this->get('/course/' . $otherKursId . '/admin/blocks/' . $otherBlockId);

--- a/tests/Feature/Admin/Block/UpdateBlockTest.php
+++ b/tests/Feature/Admin/Block/UpdateBlockTest.php
@@ -16,7 +16,7 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         $this->blockId = $this->createBlock('Block 1');
 
-        $this->payload = ['full_block_number' => '1.2', 'name' => 'Geänderter Blockname', 'block_date' => '22.12.2019', 'requirement_ids' => null];
+        $this->payload = ['full_block_number' => '1.2', 'name' => 'Geänderter Blockname', 'block_date' => '22.12.2019', 'requirements' => null];
     }
 
     public function test_shouldRequireLogin() {

--- a/tests/Feature/Admin/Block/UpdateBlockTest.php
+++ b/tests/Feature/Admin/Block/UpdateBlockTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin\Block;
 
+use App\Models\Block;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCaseWithCourse;
@@ -60,6 +61,9 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blocknummer Format ist ungültig.', $exception->validator->errors()->first('full_block_number'));
     }
 
     public function test_shouldValidateNewBlockData_noBlockname() {
@@ -72,6 +76,9 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blockname muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewBlockData_longBlockname() {
@@ -84,9 +91,12 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blockname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
-    public function test_shouldValidateNewBlockData_noDatum() {
+    public function test_shouldValidateNewBlockData_noDate() {
         // given
         $payload = $this->payload;
         unset($payload['block_date']);
@@ -96,9 +106,12 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Datum muss ausgefüllt sein.', $exception->validator->errors()->first('block_date'));
     }
 
-    public function test_shouldValidateNewBlockData_invalidDatum() {
+    public function test_shouldValidateNewBlockData_invalidDate() {
         // given
         $payload = $this->payload;
         $payload['block_date'] = 'abc';
@@ -108,6 +121,100 @@ class UpdateBlockTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Datum muss ein gültiges Datum sein.', $exception->validator->errors()->first('block_date'));
+    }
+
+    public function test_shouldValidateNewBlockData_noRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $payload['requirements'] = null;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals([], Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_invalidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $payload['requirements'] = 'xyz';
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderungen Format ist ungültig.', $exception->validator->errors()->first('requirements'));
+    }
+
+    public function test_shouldValidateNewBlockData_oneValidRequirementId() {
+        // given
+        $payload = $this->payload;
+        $requirementId = $this->createRequirement();
+        $payload['requirements'] = $requirementId;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals([$requirementId], Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_multipleValidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/blocks');
+        $this->assertEquals($requirementIds, Block::latest()->first()->requirements->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewBlockData_someNonexistentRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), '999999', $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirements'));
+    }
+
+    public function test_shouldValidateNewBlockData_someInvalidRequirementIds() {
+        // given
+        $payload = $this->payload;
+        $requirementIds = [$this->createRequirement(), 'abc', $this->createRequirement()];
+        $payload['requirements'] = implode(',', $requirementIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/blocks/' . $this->blockId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderungen Format ist ungültig.', $exception->validator->errors()->first('requirements'));
     }
 
     public function test_shouldValidateNewBlockData_wrongId() {

--- a/tests/Feature/Admin/Category/CreateCategoryTest.php
+++ b/tests/Feature/Admin/Category/CreateCategoryTest.php
@@ -52,6 +52,9 @@ class CreateCategoryTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Titel muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCategoryData_longCategoryName() {
@@ -64,6 +67,9 @@ class CreateCategoryTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Titel darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldShowMessage_whenNoCategoryInCourse() {

--- a/tests/Feature/Admin/Category/UpdateCategoryTest.php
+++ b/tests/Feature/Admin/Category/UpdateCategoryTest.php
@@ -56,6 +56,9 @@ class UpdateCategoryTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Titel muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCategoryData_longName() {
@@ -68,6 +71,9 @@ class UpdateCategoryTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Titel darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCategoryData_wrongId() {

--- a/tests/Feature/Admin/Course/CreateCourseTest.php
+++ b/tests/Feature/Admin/Course/CreateCourseTest.php
@@ -52,6 +52,9 @@ class CreateCourseTest extends TestCase {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Kursname muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCourseData_longName() {
@@ -64,6 +67,9 @@ class CreateCourseTest extends TestCase {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Kursname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCourseData_longCourseNumber() {

--- a/tests/Feature/Admin/Course/UpdateCourseTest.php
+++ b/tests/Feature/Admin/Course/UpdateCourseTest.php
@@ -52,6 +52,9 @@ class UpdateCourseTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Kursname muss ausgefüllt sein.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCourseData_longName() {
@@ -64,6 +67,9 @@ class UpdateCourseTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Kursname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('name'));
     }
 
     public function test_shouldValidateNewCourseData_longCourseNumber() {
@@ -76,6 +82,9 @@ class UpdateCourseTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Kursnummer darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('course_number'));
     }
 
     public function test_shouldValidateNewCourseData_wrongId() {

--- a/tests/Feature/Admin/Equipe/AcceptInvitationTest.php
+++ b/tests/Feature/Admin/Equipe/AcceptInvitationTest.php
@@ -106,6 +106,9 @@ class AcceptInvitationTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Token muss ausgefüllt sein.', $exception->validator->errors()->first('token'));
     }
 
     public function test_shouldValidateClaimedInvitation_longToken() {
@@ -117,6 +120,9 @@ class AcceptInvitationTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Token darf maximal 128 Zeichen haben.', $exception->validator->errors()->first('token'));
     }
 
     public function test_shouldRedirectToInvitationClaimPage_afterCompletingLogin() {

--- a/tests/Feature/Admin/Equipe/CreateInvitationTest.php
+++ b/tests/Feature/Admin/Equipe/CreateInvitationTest.php
@@ -67,6 +67,9 @@ class CreateInvitationTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('E-Mail muss ausgefüllt sein.', $exception->validator->errors()->first('email'));
     }
 
     public function test_shouldValidateNewInvitationData_longEmail() {
@@ -79,6 +82,9 @@ class CreateInvitationTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('E-Mail darf maximal 50 Zeichen haben.', $exception->validator->errors()->first('email'));
     }
 
     public function test_shouldValidateNewInvitationData_invalidEmail() {
@@ -91,6 +97,9 @@ class CreateInvitationTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('E-Mail muss eine gültige E-Mail-Adresse sein.', $exception->validator->errors()->first('email'));
     }
 
     public function test_shouldShowMessage_whenNoInvitationInCourse() {

--- a/tests/Feature/Admin/Participant/CreateParticipantTest.php
+++ b/tests/Feature/Admin/Participant/CreateParticipantTest.php
@@ -82,7 +82,7 @@ class CreateParticipantTest extends TestCaseWithCourse {
     public function test_shouldValidateNewParticipantData_longGroup() {
         // given
         $payload = $this->payload;
-        $payload['scout_name'] = 'Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname';
+        $payload['group'] = 'Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/admin/participants', $payload);

--- a/tests/Feature/Admin/Participant/CreateParticipantTest.php
+++ b/tests/Feature/Admin/Participant/CreateParticipantTest.php
@@ -65,6 +65,9 @@ class CreateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Pfadiname muss ausgefüllt sein.', $exception->validator->errors()->first('scout_name'));
     }
 
     public function test_shouldValidateNewParticipantData_longScoutName() {
@@ -77,6 +80,9 @@ class CreateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Pfadiname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('scout_name'));
     }
 
     public function test_shouldValidateNewParticipantData_longGroup() {
@@ -89,6 +95,9 @@ class CreateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Abteilung darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('group'));
     }
 
     public function test_shouldShowMessage_whenNoParticipantInCourse() {

--- a/tests/Feature/Admin/Participant/UpdateParticipantTest.php
+++ b/tests/Feature/Admin/Participant/UpdateParticipantTest.php
@@ -86,7 +86,7 @@ class UpdateParticipantTest extends TestCaseWithCourse {
     public function test_shouldValidateNewParticipantData_longGroup() {
         // given
         $payload = $this->payload;
-        $payload['scout_name'] = 'Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname';
+        $payload['group'] = 'Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname Unglaublich langer Gruppenname';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/admin/participants/' . $this->participantId, $payload);

--- a/tests/Feature/Admin/Participant/UpdateParticipantTest.php
+++ b/tests/Feature/Admin/Participant/UpdateParticipantTest.php
@@ -69,6 +69,9 @@ class UpdateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Pfadiname muss ausgefüllt sein.', $exception->validator->errors()->first('scout_name'));
     }
 
     public function test_shouldValidateNewParticipantData_longScoutName() {
@@ -81,6 +84,9 @@ class UpdateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Pfadiname darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('scout_name'));
     }
 
     public function test_shouldValidateNewParticipantData_longGroup() {
@@ -93,6 +99,9 @@ class UpdateParticipantTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Abteilung darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('group'));
     }
 
     public function test_shouldValidateNewParticipantData_wrongId() {

--- a/tests/Feature/Admin/Requirement/CreateRequirementTest.php
+++ b/tests/Feature/Admin/Requirement/CreateRequirementTest.php
@@ -52,6 +52,9 @@ class CreateRequirementTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderung muss ausgefüllt sein.', $exception->validator->errors()->first('content'));
     }
 
     public function test_shouldValidateNewRequirementData_longAnforderungText() {
@@ -64,6 +67,9 @@ class CreateRequirementTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderung darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('content'));
     }
 
     public function test_shouldValidateNewRequirementData_mandatoryNotSet_shouldWork() {

--- a/tests/Feature/Admin/Requirement/UpdateRequirementTest.php
+++ b/tests/Feature/Admin/Requirement/UpdateRequirementTest.php
@@ -58,6 +58,9 @@ class UpdateRequirementTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderung muss ausgefüllt sein.', $exception->validator->errors()->first('content'));
     }
 
     public function test_shouldValidateNewRequirementData_longAnforderungText() {
@@ -70,6 +73,9 @@ class UpdateRequirementTest extends TestCaseWithCourse {
 
         // then
         $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Anforderung darf maximal 255 Zeichen haben.', $exception->validator->errors()->first('content'));
     }
 
     public function test_shouldValidateNewRequirementData_mandatoryNotSet_shouldNotChangeMandatory() {

--- a/tests/Feature/Admin/Requirement/UpdateRequirementTest.php
+++ b/tests/Feature/Admin/Requirement/UpdateRequirementTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin\Requirement;
 
+use App\Models\Requirement;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCaseWithCourse;
@@ -16,7 +17,7 @@ class UpdateRequirementTest extends TestCaseWithCourse {
 
         $this->requirementId = $this->createRequirement('Mindestanforderung 1', true);
 
-        $this->payload = ['content' => 'Geänderte Anforderung', 'mandatory' => '1'];
+        $this->payload = ['content' => 'Geänderte Anforderung', 'mandatory' => '1', 'blocks' => null];
     }
 
     public function test_shouldRequireLogin() {
@@ -127,6 +128,97 @@ class UpdateRequirementTest extends TestCaseWithCourse {
         $response = $response->followRedirects();
         $response->assertSee('>Ja<');
         $response->assertDontSee('>Nein<');
+    }
+
+    public function test_shouldValidateNewRequirementData_noBlockIds() {
+        // given
+        $payload = $this->payload;
+        $payload['blocks'] = null;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/requirement');
+        $this->assertEquals([], Requirement::find($this->requirementId)->blocks->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewRequirementData_invalidBlockIds() {
+        // given
+        $payload = $this->payload;
+        $payload['blocks'] = 'xyz';
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blöcke Format ist ungültig.', $exception->validator->errors()->first('blocks'));
+    }
+
+    public function test_shouldValidateNewRequirementData_oneValidRequirementId() {
+        // given
+        $payload = $this->payload;
+        $blockId = $this->createBlock();
+        $payload['blocks'] = $blockId;
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/requirement');
+        $this->assertEquals([$blockId], Requirement::find($this->requirementId)->blocks->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewRequirementData_multipleValidBlockIds() {
+        // given
+        $payload = $this->payload;
+        $blockIds = [$this->createBlock(), $this->createBlock()];
+        $payload['blocks'] = implode(',', $blockIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $response->assertStatus(302);
+        $response->assertRedirect('/course/' . $this->courseId . '/admin/requirement');
+        $this->assertEquals($blockIds, Requirement::find($this->requirementId)->blocks->pluck('id')->all());
+    }
+
+    public function test_shouldValidateNewRequirementData_someNonexistentBlockIds() {
+        // given
+        $payload = $this->payload;
+        $blockIds = [$this->createBlock(), '999999', $this->createBlock()];
+        $payload['blocks'] = implode(',', $blockIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Der gewählte Wert für Blöcke ist ungültig.', $exception->validator->errors()->first('blocks'));
+    }
+
+    public function test_shouldValidateNewRequirementData_someInvalidBlockIds() {
+        // given
+        $payload = $this->payload;
+        $blockIds = [$this->createBlock(), 'abc', $this->createBlock()];
+        $payload['blocks'] = implode(',', $blockIds);
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/requirement/' . $this->requirementId, $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('Blöcke Format ist ungültig.', $exception->validator->errors()->first('blocks'));
     }
 
     public function test_shouldValidateNewRequirementData_wrongId() {

--- a/tests/Feature/App/RestoreFormDataWhenSessionExpiredTest.php
+++ b/tests/Feature/App/RestoreFormDataWhenSessionExpiredTest.php
@@ -13,7 +13,7 @@ class RestoreFormDataWhenSessionExpiredTest extends TestCaseWithBasicData {
 
     private $email = 'bari@example.com';
     private $formUrl;
-    private $participantIds;
+    private $payloadParticipants;
     private $blockIds;
     private $expectedRestoredFlashMessage = 'Deine eingegebenen Daten wurden wiederhergestellt. Speichern nicht vergessen!';
     private $payloadOverride = null;
@@ -22,7 +22,7 @@ class RestoreFormDataWhenSessionExpiredTest extends TestCaseWithBasicData {
         parent::setUp();
 
         $this->formUrl = '/course/' . $this->courseId . '/observation/new';
-        $this->participantIds = '' . $this->participantId;
+        $this->payloadParticipants = '' . $this->participantId;
         $this->blockIds = '' . $this->blockId;
 
         $this->createObservation('hat gut mitgemacht', 1, [], [], $this->blockId);
@@ -32,7 +32,7 @@ class RestoreFormDataWhenSessionExpiredTest extends TestCaseWithBasicData {
         if ($this->payloadOverride !== null) {
             return $this->payloadOverride;
         }
-        return ['participant_ids' => $this->participantIds, 'content' => 'this text will be restored', 'impression' => '1', 'block_id' => $this->blockIds, 'requirement_ids' => '', 'category_ids' => ''];
+        return ['participants' => $this->payloadParticipants, 'content' => 'this text will be restored', 'impression' => '1', 'block' => $this->blockIds, 'requirements' => '', 'categories' => ''];
     }
 
     public function test_shouldRestoreSubmittedFormData_whenLoggingBackInNormally() {
@@ -100,7 +100,7 @@ class RestoreFormDataWhenSessionExpiredTest extends TestCaseWithBasicData {
         // Participant is specified in URL
         $this->formUrl = '/course/' . $this->courseId . '/observation/new?participant=' . $this->participantId;
         // but not sent in payload, so the user deleted it from the form
-        $this->participantIds = '';
+        $this->payloadParticipants = '';
 
         $this->checkRestorationOfFormData(function () {
             // the user logs back in normally

--- a/tests/Feature/ErrorReports/SentryTest.php
+++ b/tests/Feature/ErrorReports/SentryTest.php
@@ -9,6 +9,12 @@ use Tests\TestCase;
 
 class SentryTest extends TestCase {
 
+    public function setUp(): void {
+        parent::setUp();
+        // Turn off debug mode just in this test, because in debug mode Sentry isn't called (not even our mock)
+        $_ENV['APP_DEBUG'] = false;
+    }
+
     public function test_shouldReportErrorToSentry_andDisplayErrorForm_when500ErrorOccurs() {
         // given
         $sentryMock = Mockery::mock(app('sentry'));

--- a/tests/Feature/Observation/CreateObservationTest.php
+++ b/tests/Feature/Observation/CreateObservationTest.php
@@ -19,8 +19,8 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $this->requirementId = $this->createRequirement('Mindestanforderung 1', true);
         $this->categoryId = $this->createCategory('Kategorie 1');
 
-        $this->payload = ['participant_ids' => '' . $this->participantId, 'content' => 'hat gut mitgemacht', 'impression' => '1',
-            'block_id' => '' . $this->blockId, 'requirement_ids' => '' . $this->requirementId, 'category_ids' => '' . $this->categoryId];
+        $this->payload = ['participants' => '' . $this->participantId, 'content' => 'hat gut mitgemacht', 'impression' => '1',
+            'block' => '' . $this->blockId, 'requirements' => '' . $this->requirementId, 'categories' => '' . $this->categoryId];
     }
 
     public function test_shouldRequireLogin() {
@@ -64,7 +64,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_noParticipantIds() {
         // given
         $payload = $this->payload;
-        unset($payload['participant_ids']);
+        unset($payload['participants']);
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -76,7 +76,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_invalidParticipantIds() {
         // given
         $payload = $this->payload;
-        $payload['participant_ids'] = 'a';
+        $payload['participants'] = 'a';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -90,7 +90,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $participantId2 = $this->createParticipant('Pfnörch');
         $participantIds = $this->participantId . ',' . $participantId2;
         $payload = $this->payload;
-        $payload['participant_ids'] = $participantIds;
+        $payload['participants'] = $participantIds;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -108,7 +108,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $participantId2 = $this->createParticipant('Pfnörch');
         $participantIds = $this->participantId . ',' . $participantId2;
         $payload = $this->payload;
-        $payload['participant_ids'] = $participantIds;
+        $payload['participants'] = $participantIds;
         $payload['content'] = 'visible on both participants';
 
         // when
@@ -172,7 +172,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_noBlockId() {
         // given
         $payload = $this->payload;
-        unset($payload['block_id']);
+        unset($payload['block']);
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -184,7 +184,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_invalidBlockId() {
         // given
         $payload = $this->payload;
-        $payload['block_id'] = '*';
+        $payload['block'] = '*';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -208,7 +208,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_invalidCategoryIds() {
         // given
         $payload = $this->payload;
-        $payload['category_ids'] = 'xyz';
+        $payload['categories'] = 'xyz';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -221,7 +221,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         // given
         $participantName = '<b>Participant name</b> with \'some" formatting';
         $payload = $this->payload;
-        $payload['participant_ids'] = $this->createParticipant($participantName);
+        $payload['participants'] = $this->createParticipant($participantName);
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload)->followRedirects();
@@ -236,7 +236,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $participantFromDifferentCourse = $this->createParticipant('Foreign', $differentCourse);
         $payload = $this->payload;
-        $payload['participant_ids'] = $this->participantId . ',' . $participantFromDifferentCourse;
+        $payload['participants'] = $this->participantId . ',' . $participantFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -245,7 +245,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für TN ist ungültig.', $exception->validator->errors()->first('participant_ids'));
+        $this->assertEquals('Der gewählte Wert für TN ist ungültig.', $exception->validator->errors()->first('participants'));
     }
 
     public function test_shouldNotAllowCreatingObservation_withRequirementFromADifferentCourse() {
@@ -253,7 +253,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $requirementFromDifferentCourse = $this->createRequirement('Must not be a bad person', true, $differentCourse);
         $payload = $this->payload;
-        $payload['requirement_ids'] = $this->requirementId . ',' . $requirementFromDifferentCourse;
+        $payload['requirements'] = $this->requirementId . ',' . $requirementFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -262,7 +262,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirement_ids'));
+        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirements'));
     }
 
     public function test_shouldNotAllowCreatingObservation_withCategoryFromADifferentCourse() {
@@ -270,7 +270,7 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $categoryFromDifferentCourse = $this->createCategory('Early observations', $differentCourse);
         $payload = $this->payload;
-        $payload['category_ids'] = $this->categoryId . ',' . $categoryFromDifferentCourse;
+        $payload['categories'] = $this->categoryId . ',' . $categoryFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/new', $payload);
@@ -279,6 +279,6 @@ class CreateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für Kategorien ist ungültig.', $exception->validator->errors()->first('category_ids'));
+        $this->assertEquals('Der gewählte Wert für Kategorien ist ungültig.', $exception->validator->errors()->first('categories'));
     }
 }

--- a/tests/Feature/Observation/ReadObservationTest.php
+++ b/tests/Feature/Observation/ReadObservationTest.php
@@ -70,7 +70,7 @@ class ReadObservationTest extends TestCaseWithBasicData {
         // given
         $otherCourseId = $this->createCourse('Zweiter Kurs', '', false);
         $otherParticipantId = Participant::create(['course_id' => $otherCourseId, 'scout_name' => 'Pflock'])->id;
-        $otherBlockId = Block::create(['course_id' => $otherCourseId, 'full_block_number' => '1.1', 'name' => 'Block 1', 'block_date' => '01.01.2019', 'requirement_ids' => null])->id;
+        $otherBlockId = Block::create(['course_id' => $otherCourseId, 'full_block_number' => '1.1', 'name' => 'Block 1', 'block_date' => '01.01.2019', 'requirements' => null])->id;
         $otherUserId = $this->createUser(['name' => 'Lindo'])->id;
         $otherObservationId = $this->createObservation('hat gut mitgemacht', '1', [], [], $otherBlockId, $otherParticipantId, $otherUserId);
 

--- a/tests/Feature/Observation/UpdateObservationTest.php
+++ b/tests/Feature/Observation/UpdateObservationTest.php
@@ -24,8 +24,8 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $this->requirementId = $this->createRequirement('Mindestanforderung 1', true);
         $this->categoryId = $this->createCategory('Kategorie 1');
 
-        $this->payload = ['participant_ids' => '' . $this->participantId, 'content' => 'kein Wort gesagt', 'impression' => '0',
-            'block_id' => '' . $blockId2, 'requirement_ids' => '' . $this->requirementId, 'category_ids' => '' . $this->categoryId];
+        $this->payload = ['participants' => '' . $this->participantId, 'content' => 'kein Wort gesagt', 'impression' => '0',
+            'block' => '' . $blockId2, 'requirements' => '' . $this->requirementId, 'categories' => '' . $this->categoryId];
     }
 
     public function test_shouldRequireLogin() {
@@ -70,7 +70,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
     public function test_shouldValidateNewObservationData_noParticipantIds() {
         // given
         $payload = $this->payload;
-        $payload['participant_ids'] = '';
+        $payload['participants'] = '';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -230,7 +230,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $previous = '/course/' . $this->courseId . '/participants/' . $participantId2;
         $this->get('/course/' . $this->courseId . '/observation/' . $this->observationId, [], ['referer' => $previous]);
         $payload = $this->payload;
-        $payload['participant_ids'] = $this->participantId . ',' . $participantId2;
+        $payload['participants'] = $this->participantId . ',' . $participantId2;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -248,7 +248,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $previous = '/course/' . $this->courseId . '/participants/' . $participantId2;
         $this->get('/course/' . $this->courseId . '/observation/' . $this->observationId, [], ['referer' => $previous]);
         $payload = $this->payload;
-        $payload['participant_ids'] = $this->participantId . ',' . $participantId2;
+        $payload['participants'] = $this->participantId . ',' . $participantId2;
 
         // send something which will trigger validation errors
         $payloadWithErrors = $payload;
@@ -272,7 +272,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $previous = '/course/' . $this->courseId . '/participants/' . $this->participantId;
         $this->get('/course/' . $this->courseId . '/observation/' . $this->observationId, [], ['referer' => $previous]);
         $payload = $this->payload;
-        $payload['participant_ids'] = $participantId2;
+        $payload['participants'] = $participantId2;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -287,7 +287,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $participantFromDifferentCourse = $this->createParticipant('Foreign', $differentCourse);
         $payload = $this->payload;
-        $payload['participant_ids'] = $this->participantId . ',' . $participantFromDifferentCourse;
+        $payload['participants'] = $this->participantId . ',' . $participantFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -296,7 +296,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für TN ist ungültig.', $exception->validator->errors()->first('participant_ids'));
+        $this->assertEquals('Der gewählte Wert für TN ist ungültig.', $exception->validator->errors()->first('participants'));
     }
 
     public function test_shouldNotAllowChangingRequirementToOneFromADifferentCourse() {
@@ -304,7 +304,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $requirementFromDifferentCourse = $this->createRequirement('Must not be a bad person', true, $differentCourse);
         $payload = $this->payload;
-        $payload['requirement_ids'] = $this->requirementId . ',' . $requirementFromDifferentCourse;
+        $payload['requirements'] = $this->requirementId . ',' . $requirementFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -313,7 +313,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirement_ids'));
+        $this->assertEquals('Der gewählte Wert für Anforderungen ist ungültig.', $exception->validator->errors()->first('requirements'));
     }
 
     public function test_shouldNotAllowChangingCategoryToOneFromADifferentCourse() {
@@ -321,7 +321,7 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $differentCourse = $this->createCourse('Other course', '', false);
         $categoryFromDifferentCourse = $this->createCategory('Early observations', $differentCourse);
         $payload = $this->payload;
-        $payload['category_ids'] = $this->categoryId . ',' . $categoryFromDifferentCourse;
+        $payload['categories'] = $this->categoryId . ',' . $categoryFromDifferentCourse;
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/observation/' . $this->observationId, $payload);
@@ -330,6 +330,6 @@ class UpdateObservationTest extends TestCaseWithBasicData {
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         /** @var ValidationException $exception */
         $exception = $response->exception;
-        $this->assertEquals('Der gewählte Wert für Kategorien ist ungültig.', $exception->validator->errors()->first('category_ids'));
+        $this->assertEquals('Der gewählte Wert für Kategorien ist ungültig.', $exception->validator->errors()->first('categories'));
     }
 }

--- a/tests/TestCaseWithBasicData.php
+++ b/tests/TestCaseWithBasicData.php
@@ -18,7 +18,7 @@ abstract class TestCaseWithBasicData extends TestCaseWithCourse
     }
 
     protected function createObservation($content = 'hat gut mitgemacht', $impression = 1, $requirementId = [], $categoryIds = [], $blockId = null, $participantIds = null, $userId = null) {
-        $observation = Observation::create(['user_id' => ($userId !== null ? $userId : $this->user()->id), 'block_id' => ($blockId !== null ? $blockId : $this->blockId), 'content' => $content, 'impression' => $impression]);
+        $observation = Observation::create(['user_id' => ($userId !== null ? $userId : $this->user()->id), 'block' => ($blockId !== null ? $blockId : $this->blockId), 'content' => $content, 'impression' => $impression]);
         $observation->requirements()->attach($requirementId);
         $observation->categories()->attach($categoryIds);
         $observation->participants()->attach(($participantIds !== null ? Arr::wrap($participantIds) : [$this->participantId]));


### PR DESCRIPTION
Fixes #75 
Also, refactors the FormRequests so that validation of one-to-many and many-to-many associations can be done directly in the FormRequests, and renames fields like `requirement_ids` to `requirements` etc. to still provide correct validation error messages.
Now, you can validate whether the related entites (that the user selects in a Multiselect dropdown) all exist in the course:
```php
[
    'requirements' => 'required|regex:/^\d+(,\d+)*$/|allExistInCourse',
    'block' => 'required|regex:/^\d+$/|existsInCourse'`,
]
```