### PR TITLE
Fix autofocus for multiselects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
     '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest'
   },
+  setupFilesAfterEnv: ['<rootDir>/tests/Vue/jest-setup.js'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,6 +1902,106 @@
                 }
             }
         },
+        "@testing-library/jest-dom": {
+            "version": "5.11.9",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+            "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^4.2.2",
+                "chalk": "^3.0.0",
+                "css": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "css": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+                    "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.4",
+                        "source-map": "^0.6.1",
+                        "source-map-resolve": "^0.6.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-resolve": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+                    "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+                    "dev": true,
+                    "requires": {
+                        "atob": "^2.1.2",
+                        "decode-uri-component": "^0.2.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "@testing-library/vue": {
             "version": "5.6.1",
             "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-5.6.1.tgz",
@@ -2254,6 +2354,16 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/jest": {
+            "version": "26.0.20",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
+            "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+            "dev": true,
+            "requires": {
+                "jest-diff": "^26.0.0",
+                "pretty-format": "^26.0.0"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -2356,6 +2466,15 @@
             "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-1.3.3.tgz",
             "integrity": "sha512-eDLVUvvTn+mol3NpP211DTH9JzSS6YKssRIhHNmXk5BiCl+gc4s+xQQjRFTSsGBohmka5qBsHX6qhL4x88Wkvg==",
             "dev": true
+        },
+        "@types/testing-library__jest-dom": {
+            "version": "5.9.5",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+            "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+            "dev": true,
+            "requires": {
+                "@types/jest": "*"
+            }
         },
         "@types/yargs": {
             "version": "15.0.13",
@@ -4760,6 +4879,12 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
             "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+            "dev": true
+        },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
             "dev": true
         },
         "cssesc": {
@@ -10120,6 +10245,12 @@
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
+        "min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true
+        },
         "mini-css-extract-plugin": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.4.tgz",
@@ -12944,6 +13075,16 @@
                 "resolve": "^1.9.0"
             }
         },
+        "redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "requires": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            }
+        },
         "regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -14278,6 +14419,15 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
+        },
+        "strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "requires": {
+                "min-indent": "^1.0.0"
+            }
         },
         "strip-json-comments": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@sentry/browser": "^5.24.2",
         "@sentry/integrations": "^5.24.2",
         "@sentry/tracing": "^5.24.2",
+        "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/vue": "^5.6.1",
         "axios": "^0.21.1",
         "babel-core": "^7.0.0-bridge.0",

--- a/resources/js/components/MultiSelect.vue
+++ b/resources/js/components/MultiSelect.vue
@@ -47,7 +47,8 @@ export default {
     groups: { type: Object, default: () => ({}) },
     submitOnInput: { type: String, required: false },
     showClear: { type: Boolean, default: false },
-    placeholder: { type: String, default: '' }
+    placeholder: { type: String, default: '' },
+    autofocus: { type: Boolean, default: false }
   },
   data() {
     return {
@@ -124,6 +125,10 @@ export default {
   },
   mounted () {
     this.$emit('input', this.formValue, this.$attrs['id'])
+
+    if (this.autofocus) {
+      this.$refs.multiselect.activate()
+    }
   }
 }
 </script>

--- a/resources/views/observation/new.blade.php
+++ b/resources/views/observation/new.blade.php
@@ -16,8 +16,7 @@
                     $course->participantGroups->mapWithKeys(function ($group) {
                         return [$group['group_name'] => $group->participants->pluck('id')->join(',')];
                     }), JSON_FORCE_OBJECT)}}"
-
-            display-field="scout_name"
+                display-field="scout_name"
                 multiple
                 required
                 :autofocus="{{ $participants === null ? 'true' : 'false' }}"></input-multi-select>

--- a/tests/Vue/components/MultiSelect.spec.js
+++ b/tests/Vue/components/MultiSelect.spec.js
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import MultiSelect from "../../../resources/js/components/MultiSelect"
+
+test('should activate when autofocus is set', async () => {
+  render(MultiSelect, {
+    propsData: {
+      options: [{ id: 1, label: 'test'}, { id: 2, label: 'test2' }],
+      autofocus: true,
+    },
+    mocks: { '$t': () => {} }
+  })
+
+  await waitFor(() => {
+    expect(screen.getByText('test')).toBeVisible()
+    expect(screen.getByText('test2')).toBeVisible()
+  })
+})
+
+test('should not activate automatically when autofocus is not set', () => {
+  render(MultiSelect, {
+    propsData: {
+      options: [{ id: 1, label: 'test'}, { id: 2, label: 'test2' }],
+    },
+    mocks: { '$t': () => {} }
+  })
+
+  // The select options should never become visible
+  return expect(waitFor(() => {
+    expect(screen.getByText('test')).toBeVisible()
+    expect(screen.getByText('test2')).toBeVisible()
+  })).rejects.toThrow(/Received element is not visible/)
+})

--- a/tests/Vue/components/TableObservationOverview.spec.js
+++ b/tests/Vue/components/TableObservationOverview.spec.js
@@ -4,9 +4,10 @@ import TableObservationOverview from "../../../resources/js/components/TableObse
 test('should display the correct color classes', () => {
   const table = render(TableObservationOverview, {
     props: {
-      users: [{ id: 1, name: 'Bari' }, { id: 2, name: 'Lindo' }, { id: 3, name: 'Cosinus' }],
+      users: [{ id: 1, name: 'Bari' }, { id: 2, name: 'Lindo' }, { id: 3, name: 'Cosinus' },
+              { id: 4, name: 'Bari2' }, { id: 5, name: 'Lindo2' }, { id: 6, name: 'Cosinus2' }],
       participants: [{ id: 101, scout_name: 'Pflock', course_id: 7, observation_counts_by_user: {
-          1: 20, 2: 7, 3: 2
+          1: 30, 2: 20, 3: 19, 4: 7, 5: 6, 6: 2
       } }],
       redThreshold: 7,
       greenThreshold: 20,
@@ -15,10 +16,16 @@ test('should display the correct color classes', () => {
     stubs: [ 'b-table-simple', 'b-thead', 'b-tbody', 'b-tr' ],
   })
 
-  expect(table.getByText('20').classList).not.toContain('bg-danger-light')
-  expect(table.getByText('20').classList).toContain('bg-success-light')
-  expect(table.getByText('7').classList).not.toContain('bg-danger-light')
-  expect(table.getByText('7').classList).not.toContain('bg-success-light')
-  expect(table.getByText('2').classList).toContain('bg-danger-light')
-  expect(table.getByText('2').classList).not.toContain('bg-success-light')
+  expect(table.getByText('30')).not.toHaveClass('bg-danger-light')
+  expect(table.getByText('30')).toHaveClass('bg-success-light')
+  expect(table.getByText('20')).not.toHaveClass('bg-danger-light')
+  expect(table.getByText('20')).toHaveClass('bg-success-light')
+  expect(table.getByText('19')).not.toHaveClass('bg-danger-light')
+  expect(table.getByText('19')).not.toHaveClass('bg-success-light')
+  expect(table.getByText('7')).not.toHaveClass('bg-danger-light')
+  expect(table.getByText('7')).not.toHaveClass('bg-success-light')
+  expect(table.getByText('6')).toHaveClass('bg-danger-light')
+  expect(table.getByText('6')).not.toHaveClass('bg-success-light')
+  expect(table.getByText('2')).toHaveClass('bg-danger-light')
+  expect(table.getByText('2')).not.toHaveClass('bg-success-light')
 })

--- a/tests/Vue/jest-setup.js
+++ b/tests/Vue/jest-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
Apparently, the multiselects haven't been reacting to `autofocus` (at least recently). This can be seen when going to the Spick page and clicking on a block to create an observation. The TN multiselect then has the `autofocus` attribute set.