### PR TITLE
Allow long observations

### DIFF
--- a/database/migrations/2021_10_18_203701_allow_long_observations.php
+++ b/database/migrations/2021_10_18_203701_allow_long_observations.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AllowLongObservations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('observations', function (Blueprint $table) {
+            $table->string("content", 4048)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('observations', function (Blueprint $table) {
+            $table->string("content", 1023)->change();
+        });
+    }
+}


### PR DESCRIPTION
Increase the length of the content field of the observation table to
allow observations of up to 4048 letters.