### PR TITLE
Quali observation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Mai 2022
 - Wenn mit dem Back-Button zurück auf ein Quali navigiert wird, wird jetzt der wirklich aktuellste Quali-Inhalt angezeigt [#250](https://github.com/gloggi/qualix/issues/250)
+- Beim Einfügen von Beobachtungen in ein Quali können jetzt optional diejenigen Beobachtungen herausgefiltert werden, die bereits im Quali eingesetzt wurden (merci für die Idee @Tschet1) [#230](https://github.com/gloggi/qualix/issues/230)
 
 ##### April 2022
 - Kontaktlink im Footer hinzugefügt [#233](https://github.com/gloggi/qualix/issues/233)

--- a/resources/js/components/ObservationList.vue
+++ b/resources/js/components/ObservationList.vue
@@ -184,7 +184,7 @@ export default {
   methods: {
     persistFilter(key, value) {
       if (!this.courseId) return
-      this.storage[key] = value ? value : null;
+      this.storage[key] = value != null ? value : null;
       const alteredStorage = this.allStorage
       alteredStorage[this.courseId] = this.storage
       localStorage.courses = JSON.stringify(alteredStorage)
@@ -205,11 +205,15 @@ export default {
     }
 
     if (this.anyCategories) {
-      const storedCategory = storage.selectedCategory
+      const storedCategory = this.storage.selectedCategory
       if (storedCategory !== null) {
         if (storedCategory === 0) this.selectedCategory = this.noCategoryOption
-        else this.selectedCategory = this.categories.find(cat => cat.id === storage.selectedCategory) ?? null;
+        else this.selectedCategory = this.categories.find(cat => cat.id === storedCategory) ?? null;
       }
+    }
+
+    if (this.usedObservations !== null) {
+      this.hideUsedObservations = !!this.storage.hideUsedObservations
     }
   },
   watch: {

--- a/resources/js/components/ObservationList.vue
+++ b/resources/js/components/ObservationList.vue
@@ -1,60 +1,63 @@
 <template>
   <div>
+    <template v-if="anyRequirements || anyCategories || null !== usedObservations">
 
-    <b-button variant="link" block class="mb-2 text-left" v-b-toggle.filters-collapse v-if="anyRequirements || anyCategories">
-      <i class="fas fa-filter"></i> {{ $t('t.views.participant_details.filter') }} <i class="fas fa-caret-down"></i>
-    </b-button>
+      <b-button variant="link" block class="mb-2 text-left" v-b-toggle.filters-collapse>
+        <i class="fas fa-filter"></i> {{ $t('t.views.participant_details.filter') }} <i class="fas fa-caret-down"></i>
+      </b-button>
 
-    <b-collapse id="filters-collapse" :visible="filtersVisibleInitially" v-if="anyRequirements || anyCategories || null !== usedObservations">
-      <b-row>
+      <b-collapse id="filters-collapse" :visible="filtersVisibleInitially">
+        <b-row>
 
-        <b-col cols="12" md="6" v-if="anyRequirements">
-          <multi-select
-            id="filter-requirements"
-            name="filter-requirements"
-            class="form-control-multiselect"
-            :selected.sync="selectedRequirement"
-            :allow-empty="true"
-            :placeholder="$t('t.views.participant_details.filter_by_requirement')"
-            :options="requirementOptions"
-            :multiple="false"
-            :close-on-select="true"
-            :show-labels="false"
-            :show-clear="true"
-            display-field="content"></multi-select>
-        </b-col>
+          <b-col cols="12" md="6" v-if="anyRequirements">
+            <multi-select
+              id="filter-requirements"
+              name="filter-requirements"
+              class="form-control-multiselect"
+              :selected.sync="selectedRequirement"
+              :allow-empty="true"
+              :placeholder="$t('t.views.participant_details.filter_by_requirement')"
+              :options="requirementOptions"
+              :multiple="false"
+              :close-on-select="true"
+              :show-labels="false"
+              :show-clear="true"
+              display-field="content"></multi-select>
+          </b-col>
 
-        <b-col cols="12" md="6" v-if="anyCategories">
-          <multi-select
-            id="filter-categories"
-            name="filter-categories"
-            class="form-control-multiselect"
-            :selected.sync="selectedCategory"
-            :allow-empty="true"
-            :placeholder="$t('t.views.participant_details.filter_by_category')"
-            :options="categoryOptions"
-            :multiple="false"
-            :close-on-select="true"
-            :show-labels="false"
-            :show-clear="true"
-            display-field="name"></multi-select>
-        </b-col>
+          <b-col cols="12" md="6" v-if="anyCategories">
+            <multi-select
+              id="filter-categories"
+              name="filter-categories"
+              class="form-control-multiselect"
+              :selected.sync="selectedCategory"
+              :allow-empty="true"
+              :placeholder="$t('t.views.participant_details.filter_by_category')"
+              :options="categoryOptions"
+              :multiple="false"
+              :close-on-select="true"
+              :show-labels="false"
+              :show-clear="true"
+              display-field="name"></multi-select>
+          </b-col>
 
-        <b-col cols="12" md="6" v-if="null !== usedObservations">
-          <label for="hide-already-used-observations" class="d-flex w-100 h-100 align-items-center">
-            <b-form-checkbox
-              type="checkbox"
-              id="hide-already-used-observations"
-              v-model="hideUsedObservations"
-              :switch="true"
-              size="xl"
-            ></b-form-checkbox>
-            <span>{{ $t('t.views.participant_details.hide_already_used_observations') }}</span>
-          </label>
-        </b-col>
+          <b-col cols="12" md="6" v-if="null !== usedObservations">
+            <label for="hide-already-used-observations" class="d-flex w-100 h-100 align-items-center">
+              <b-form-checkbox
+                type="checkbox"
+                id="hide-already-used-observations"
+                v-model="hideUsedObservations"
+                :switch="true"
+                size="xl"
+              ></b-form-checkbox>
+              <span>{{ $t('t.views.participant_details.hide_already_used_observations') }}</span>
+            </label>
+          </b-col>
 
-      </b-row>
-    </b-collapse>
+        </b-row>
+      </b-collapse>
+
+    </template>
 
     <responsive-table
       class="mt-3 mt-lg-0"

--- a/resources/js/components/quali/QualiEditor.vue
+++ b/resources/js/components/quali/QualiEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editor" :class="{ 'focus': focused }">
-    <modal-add-observation v-if="observations.length" :observations="observations" v-model="addObservation" :return-focus="{ $el: { focus: () => editor.commands.focus() } }" :show-requirements="showRequirements" :show-categories="showCategories" :show-impression="showImpression"></modal-add-observation>
+    <modal-add-observation v-if="observations.length" :observations="observations" v-model="addObservation" :return-focus="{ $el: { focus: () => editor.commands.focus() } }" :used-observations="usedObservationIds" :show-requirements="showRequirements" :show-categories="showCategories" :show-impression="showImpression"></modal-add-observation>
     <input-hidden v-if="name" :value="formValue" :name="name"></input-hidden>
     <editor-floating-menu v-if="!readonly && editor" :editor="editor" :tippy-options="{ zIndex: 1 }">
       <floating-menu :observations="observations" :editor="editor" @addObservation="showObservationSelectionModal(true)"/>
@@ -28,10 +28,11 @@ import NodeRequirement from './tiptap-extensions/requirement/NodeRequirement.js'
 import GapCursorFocus from './tiptap-extensions/GapCursorFocus'
 import InputHidden from '../form/InputHidden'
 import FloatingMenu from './FloatingMenu'
+import ModalAddObservation from './tiptap-extensions/observation/ModalAddObservation'
 
 export default {
   name: 'QualiEditor',
-  components: {FloatingMenu, InputHidden, EditorContent, EditorFloatingMenu},
+  components: {FloatingMenu, InputHidden, EditorContent, EditorFloatingMenu, ModalAddObservation},
   props: {
     name: { type: String },
     courseId: { type: String, required: true },
@@ -102,7 +103,12 @@ export default {
     },
     getEmptyParagraph() {
       return () => cloneDeep(this.emptyDocument.content[0])
-    }
+    },
+    usedObservationIds() {
+      return this.currentValue.content
+        .filter(node => node.type === 'observation')
+        .map(node => node.attrs.id)
+    },
   },
   methods: {
     withCollaboration (extensions) {
@@ -219,6 +225,3 @@ const hashCode = function (string) {
 }
 </script>
 
-<style scoped>
-
-</style>

--- a/resources/js/components/quali/tiptap-extensions/observation/ModalAddObservation.vue
+++ b/resources/js/components/quali/tiptap-extensions/observation/ModalAddObservation.vue
@@ -12,6 +12,7 @@
       :observations="observations"
       :requirements="requirements"
       :categories="categories"
+      :used-observations="usedObservations"
       show-content
       show-block
       show-user
@@ -34,6 +35,7 @@ export default {
     value: {type: Function, required: false},
     observations: {type: Array, required: true},
     returnFocus: {type: Object, required: false},
+    usedObservations: {type: Array, default: null},
     showRequirements: {type: Boolean, default: false},
     showCategories: {type: Boolean, default: false},
     showImpression: {type: Boolean, default: false},

--- a/resources/lang/de/t.php
+++ b/resources/lang/de/t.php
@@ -450,6 +450,7 @@ return array(
 			"filter" => "Beobachtungen filtern",
 			"filter_by_category" => "Kategorie",
 			"filter_by_requirement" => "Anforderung",
+			"hide_already_used_observations" => "Beobachtungen ausblenden, wenn sie schon in diesem Quali eingesetzt wurden",
 			"no_observations" => "Keine Beobachtungen gefunden.",
 			"num_observations" => "{0}Bisher keine Beobachtungen.|{1}Erst eine Beobachtung. Da geht noch mehr!|[2,*]:count Beobachtungen, davon :positive mit positivem, :neutral mit neutralem und :negative mit negativem Eindruck.",
 			"observations_without_category" => "Beobachtungen ohne Kategorie",

--- a/resources/lang/de/t.php
+++ b/resources/lang/de/t.php
@@ -450,7 +450,7 @@ return array(
 			"filter" => "Beobachtungen filtern",
 			"filter_by_category" => "Kategorie",
 			"filter_by_requirement" => "Anforderung",
-			"hide_already_used_observations" => "Beobachtungen ausblenden, wenn sie schon in diesem Quali eingesetzt wurden",
+			"hide_already_used_observations" => "Beobachtungen ausblenden, wenn sie in diesem Quali schon eingesetzt wurden",
 			"no_observations" => "Keine Beobachtungen gefunden.",
 			"num_observations" => "{0}Bisher keine Beobachtungen.|{1}Erst eine Beobachtung. Da geht noch mehr!|[2,*]:count Beobachtungen, davon :positive mit positivem, :neutral mit neutralem und :negative mit negativem Eindruck.",
 			"observations_without_category" => "Beobachtungen ohne Kategorie",

--- a/tests/Vue/components/ObservationList.spec.js
+++ b/tests/Vue/components/ObservationList.spec.js
@@ -196,7 +196,7 @@ describe('visible columns', () => {
 })
 
 describe('filters', () => {
-  it('should display both filters when there are requirements and categories', () => {
+  it('should display all filters when there are requirements and categories and used observations', () => {
     const list = render(ObservationList, {
       props: {
         courseId: '1',
@@ -209,6 +209,7 @@ describe('filters', () => {
         categories: [{
           name: 'my category'
         }],
+        usedObservations: [ 1 ],
       },
       mocks: {'$t': (key) => key},
       stubs: ['b-table-simple', 'b-thead', 'b-tbody', 'b-tr', 'b-button', 'b-collapse', 'b-row', 'b-col', 'multi-select'],
@@ -233,6 +234,7 @@ describe('filters', () => {
         categories: [{
           name: 'my category'
         }],
+        usedObservations: [ 1 ],
       },
       mocks: {'$t': (key) => key},
       stubs: ['b-table-simple', 'b-thead', 'b-tbody', 'b-tr', 'b-button', 'b-collapse', 'b-row', 'b-col', 'multi-select'],
@@ -257,6 +259,7 @@ describe('filters', () => {
           content: 'some requirement'
         }],
         categories: [],
+        usedObservations: [ 1 ],
       },
       mocks: {'$t': (key) => key},
       stubs: ['b-table-simple', 'b-thead', 'b-tbody', 'b-tr', 'b-button', 'b-collapse', 'b-row', 'b-col', 'multi-select'],
@@ -268,6 +271,32 @@ describe('filters', () => {
     expect(list.getByText('t.views.participant_details.filter')).toBeInTheDocument()
     expect(list.getByPlaceholderText('t.views.participant_details.filter_by_requirement')).toBeInTheDocument()
     expect(list.queryByPlaceholderText('t.views.participant_details.filter_by_category')).toBeNull()
+  })
+
+  it('should not display the used observation filter when no used observations are passed in', () => {
+    const list = render(ObservationList, {
+      props: {
+        courseId: '1',
+        showContent: true,
+        showUser: true,
+        observations,
+        requirements: [{
+          content: 'some requirement'
+        }],
+        categories: [{
+          name: 'my category'
+        }],
+      },
+      mocks: {'$t': (key) => key},
+      stubs: ['b-table-simple', 'b-thead', 'b-tbody', 'b-tr', 'b-button', 'b-collapse', 'b-row', 'b-col', 'multi-select'],
+      directives: {
+        bToggle: () => {}
+      }
+    })
+
+    expect(list.getByText('t.views.participant_details.filter')).toBeInTheDocument()
+    expect(list.getByPlaceholderText('t.views.participant_details.filter_by_requirement')).toBeInTheDocument()
+    expect(list.getByPlaceholderText('t.views.participant_details.filter_by_category')).toBeInTheDocument()
   })
 
   it('should not display the filters at all when there are no requirements and no categories', () => {
@@ -290,5 +319,28 @@ describe('filters', () => {
     expect(list.queryByText('t.views.participant_details.filter')).toBeNull()
     expect(list.queryByPlaceholderText('t.views.participant_details.filter_by_requirement')).toBeNull()
     expect(list.queryByPlaceholderText('t.views.participant_details.filter_by_category')).toBeNull()
+    expect(list.queryByText('t.views.participant_details.hide_already_used_observations')).toBeNull()
+  })
+
+  it('should display the used observation filter when used observations are passed in', () => {
+    const list = render(ObservationList, {
+      props: {
+        courseId: '1',
+        showContent: true,
+        showUser: true,
+        observations,
+        requirements: [],
+        categories: [],
+        usedObservations: [],
+      },
+      mocks: {'$t': (key) => key},
+      stubs: ['b-table-simple', 'b-thead', 'b-tbody', 'b-tr', 'b-button', 'b-collapse', 'b-row', 'b-col', 'multi-select'],
+      directives: {
+        bToggle: () => {}
+      }
+    })
+
+    expect(list.queryByText('t.views.participant_details.filter')).toBeInTheDocument()
+    expect(list.queryByText('t.views.participant_details.hide_already_used_observations')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Fixes #230
Also refactors the localStorage handling code.
I left the default at unchecked (showing all observations, not filtering out used ones), in order to not surprise previous users, and because I did not want to have to always open the filter dropdown just to show the users this new feature. Once a user has activated the filter, it stays active (via localStorage) in all Qualis of the same course for them.

![Screenshot from 2022-05-22 15-42-24](https://user-images.githubusercontent.com/7566995/169698231-edbe7b0d-9099-486a-a776-d60b3080ade1.png)
