### PR TITLE
Don't crash when deleting a course with participants without image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Juni 2022
 - Upgrade auf Laravel 9 und PHP >= 8.0.2 [#254](https://github.com/gloggi/qualix/pull/254)
+- Bugfix: Es tritt jetzt kein Fehler mehr auf wenn man einen Kurs archiviert oder löscht der TN ohne Bild enthält
 
 ##### Mai 2022
 - Wenn mit dem Back-Button zurück auf ein Quali navigiert wird, wird jetzt der wirklich aktuellste Quali-Inhalt angezeigt [#250](https://github.com/gloggi/qualix/issues/250)

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -84,9 +84,7 @@ class CourseController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function delete(Request $request, Course $course) {
-        $participantImageUrls = $course->participants->map(function (Participant $participant) {
-            return $participant->image_url;
-        });
+        $participantImageUrls = $this->participantImageUrlsFor($course);
         // Because of the ON DELETE CASCADE on database constraints, this will also delete all related data
         $course->delete();
         // Perform the image deletion after database deletion, so that a failing image doesn't prevent the whole deletion operation.
@@ -107,9 +105,7 @@ class CourseController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function archive(Request $request, Course $course) {
-        $participantImageUrls = $course->participants->map(function (Participant $participant) {
-            return $participant->image_url;
-        });
+        $participantImageUrls = $this->participantImageUrlsFor($course);
         // Because of the ON DELETE CASCADE on database constraints, this will also delete all directly associated related data like blocks
         DB::transaction(function() use ($course) {
             $course->participants()->delete();
@@ -123,5 +119,13 @@ class CourseController extends Controller {
         }
         $request->session()->flash('alert-success', __('t.views.admin.course_settings.archive_success', ['name' => $course->name]));
         return Redirect::route('home');
+    }
+
+    /**
+     * @param Course $course
+     * @return \Illuminate\Support\Collection
+     */
+    private function participantImageUrlsFor(Course $course) {
+        return $course->participants()->whereNotNull('image_url')->pluck('image_url');
     }
 }

--- a/tests/Feature/Admin/Course/ArchiveCourseTest.php
+++ b/tests/Feature/Admin/Course/ArchiveCourseTest.php
@@ -116,6 +116,18 @@ class ArchiveCourseTest extends TestCaseWithBasicData {
         // then
     }
 
+    public function test_shouldHandleNullParticipantImageGracefully() {
+        // given
+        Participant::find($this->participantId)->update(['image_url' => null]);
+        Storage::fake();
+        Storage::shouldReceive('delete')->never();
+
+        // when
+        $this->post('/course/' . $this->courseId . '/admin/archive');
+
+        // then
+    }
+
     public function test_shouldShowEscapedNotice_afterArchivingCourse() {
         // given
         $courseName = '<b>Course name</b> with \'some" formatting';

--- a/tests/Feature/Admin/Course/DeleteCourseTest.php
+++ b/tests/Feature/Admin/Course/DeleteCourseTest.php
@@ -100,6 +100,18 @@ class DeleteCourseTest extends TestCaseWithBasicData {
         // then
     }
 
+    public function test_shouldHandleNullParticipantImageGracefully() {
+        // given
+        Participant::find($this->participantId)->update(['image_url' => null]);
+        Storage::fake();
+        Storage::shouldReceive('delete')->never();
+
+        // when
+        $this->delete('/course/' . $this->courseId . '/admin');
+
+        // then
+    }
+
     public function test_shouldShowEscapedNotice_afterDeletingCourse() {
         // given
         $courseName = '<b>Course name</b> with \'some" formatting';


### PR DESCRIPTION
The filesystem handler does not like being called with a null path.
Fixes https://sentry.io/organizations/aure4/issues/3314798177