### PR TITLE
Respect the COLLABORATION_ENABLED .env flag also in the requirements matrix

### DIFF
--- a/resources/js/components/feedback/requirements_matrix/RequirementsMatrix.vue
+++ b/resources/js/components/feedback/requirements_matrix/RequirementsMatrix.vue
@@ -14,6 +14,7 @@
         :feedback="feedback"
         :all-requirements="allRequirements"
         :requirement-statuses="requirementStatuses"
+        :collaboration-enabled="collaborationEnabled"
       />
     </b-tbody>
   </b-table-simple>
@@ -32,6 +33,7 @@ export default {
     feedbacks: { type: Array, required: true },
     allRequirements: { type: Array, required: true },
     requirementStatuses: { type: Array, default: () => [] },
+    collaborationEnabled: { type: Boolean, default: false },
   },
   computed: {
     sortedRequirements() {

--- a/resources/js/components/feedback/requirements_matrix/RequirementsMatrixRow.vue
+++ b/resources/js/components/feedback/requirements_matrix/RequirementsMatrixRow.vue
@@ -47,6 +47,7 @@ export default {
     feedback: {type: Object, required: true},
     allRequirements: {type: Array, required: true},
     requirementStatuses: {type: Array, required: true},
+    collaborationEnabled: { type: Boolean, default: false },
   },
   data: function () {
     const editor = this.createEditor()
@@ -124,7 +125,7 @@ export default {
       })
     },
     createCollaborationExtension() {
-      if (!window.crypto.subtle || !this.feedback.collaborationKey) {
+      if (!window.crypto.subtle || !this.feedback.collaborationKey || !this.collaborationEnabled) {
         // We are in an environment where crypto and thus syncing is not available
         // This currently happens only in the Cypress E2E tests
         return []

--- a/resources/views/feedback/requirements-matrix.blade.php
+++ b/resources/views/feedback/requirements-matrix.blade.php
@@ -14,7 +14,8 @@
                 :feedbacks="{{ json_encode($feedbacks) }}"
                 :all-requirements="{{ json_encode($allRequirements) }}"
                 :all-participants="{{ json_encode($allParticipants) }}"
-                :requirement-statuses="{{ json_encode($course->requirement_statuses) }}"></requirements-matrix>
+                :requirement-statuses="{{ json_encode($course->requirement_statuses) }}"
+                :collaboration-enabled="{{ json_encode(env('COLLABORATION_ENABLED')) }}"></requirements-matrix>
 
         @else
 


### PR DESCRIPTION
When `COLLABORATION_ENABLED=false`, our CSP forbids to contact the signaling servers, so we should not attempt to access them. In the feedback editor, this was already done correctly, but in the requirements matrix it was forgotten.

Thanks @cleverer for finding this!
