### PR TITLE
fix: move all env() calls to config

### DIFF
--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -67,4 +67,8 @@ ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   cd $SSH_DIRECTORY
   php artisan storage:link
   php artisan migrate --force
+
+  php artisan config:cache
+  php artisan route:cache
+  php artisan view:cache
 EOF

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -51,7 +51,7 @@ class Handler extends ExceptionHandler
      * @throws Throwable
      */
     public function report(Throwable $exception) {
-        if (!env('APP_DEBUG') && app()->bound('sentry') && $this->shouldReport($exception)) {
+        if (!config('app.debug') && app()->bound('sentry') && $this->shouldReport($exception)) {
             app('sentry')->captureException($exception);
         }
 

--- a/app/Http/Controllers/ErrorReportController.php
+++ b/app/Http/Controllers/ErrorReportController.php
@@ -21,8 +21,8 @@ class ErrorReportController extends Controller {
         $params = $request->validated();
         $request->session()->flash('previousUrl', $params['previousUrl']);
         $client = app(GuzzleHttp\Client::class);
-        $url = env('SENTRY_USER_FEEDBACK_URL');
-        $dsn = env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN'));
+        $url = config('app.sentry.user_feedback_url');
+        $dsn = config('sentry.dsn');
         $client->post($url, [
             'headers' => ['Authorization' => 'DSN ' . $dsn],
             'form_params' => [

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -73,18 +73,18 @@ class SecurityHeaders {
     }
 
     protected function getCSPConnectSrc() {
-        if (!env('COLLABORATION_ENABLED')) return '';
+        if (!config('app.collaboration.enabled')) return '';
 
         $sentryUrl = '';
-        if (env('MIX_SENTRY_VUE_DSN')) {
-            $parsed = parse_url(env('MIX_SENTRY_VUE_DSN'));
+        if (config('app.sentry.mix.vue_dsn')) {
+            $parsed = parse_url(config('app.sentry.mix.vue_dsn'));
             $sentryUrl = $parsed['scheme'] . '://' . $parsed['host'] . (isset($parsed['port']) ? ':' . $parsed['port'] : '');
         }
-        return "connect-src 'self' $sentryUrl " . env('COLLABORATION_SIGNALING_SERVERS');
+        return "connect-src 'self' $sentryUrl " . config('app.collaboration.signaling_servers');
     }
 
     protected function getCSPReportUri() {
-        $reportUri = env('SENTRY_CSP_REPORT_URI', false);
+        $reportUri = config('app.sentry.csp_report_uri', false);
         if ($reportUri) return "report-uri $reportUri&sentry_environment=" . App::environment();
         return '';
     }

--- a/config/app.php
+++ b/config/app.php
@@ -230,4 +230,22 @@ return [
         // 'ExampleClass' => App\Example\ExampleClass::class,
     ])->toArray(),
 
+    'collaboration' => [
+        'enabled' => (bool) env('COLLABORATION_ENABLED', false),
+        'signaling_servers' => env('COLLABORATION_SIGNALING_SERVERS', false)
+    ],
+
+    'contact' => [
+        'link' => env('APP_CONTACT_LINK'),
+        'text' => env('APP_CONTACT_TEXT'),
+    ],
+
+    'sentry' => [
+        'user_feedback_url' => env('SENTRY_USER_FEEDBACK_URL'),
+        'mix' => [
+            'vue_dsn' => env('MIX_SENTRY_VUE_DSN'),
+        ],
+        'csp_report_uri' => env('sentry.csp_report_uri'),
+    ]
+
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,7 +5,7 @@
     <b-card>
         <template #header>{{__('Login')}}</template>
 
-        @if (!empty(env('HITOBITO_BASE_URL')))
+        @if (!empty(config('services.hitobito.client_id')))
             <div class="form-group row">
                 <div class="col-md-6 offset-md-3">
                     <a

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     <b-card>
         <template #header>{{__('Register')}}</template>
-        @if (!empty(env('HITOBITO_BASE_URL')))
+        @if (!empty(config('services.hitobito.client_id')))
             <div class="form-group row required">
                 <div class="col-md-6 offset-md-3">
                     <a

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -7,7 +7,7 @@
     <b-card>
         <template #header>{{__('Server Error')}}</template>
 
-        @if(app()->bound('sentry') && app('sentry')->getLastEventId() && env('SENTRY_USER_FEEDBACK_URL'))
+        @if(app()->bound('sentry') && app('sentry')->getLastEventId() && config('app.sentry.user_feedback_url'))
 
             <h5>{{__('t.views.error_form.it_looks_like_we_are_having_issues')}}</h5>
 

--- a/resources/views/feedback/requirements-matrix.blade.php
+++ b/resources/views/feedback/requirements-matrix.blade.php
@@ -17,7 +17,7 @@
                 :all-requirements="{{ json_encode($allRequirements) }}"
                 :all-participants="{{ json_encode($allParticipants) }}"
                 :requirement-statuses="{{ json_encode($course->requirement_statuses) }}"
-                :collaboration-enabled="{{ json_encode(env('COLLABORATION_ENABLED')) }}"></requirements-matrix>
+                :collaboration-enabled="{{ json_encode(config('app.collaboration.enabled')) }}"></requirements-matrix>
 
         @else
 

--- a/resources/views/feedbackContent/edit.blade.php
+++ b/resources/views/feedbackContent/edit.blade.php
@@ -21,7 +21,7 @@
             :show-requirements="{{ $course->uses_requirements ? 'true' : 'false' }}"
             :show-categories="{{ $course->uses_categories ? 'true' : 'false' }}"
             :show-impression="{{ $course->uses_impressions ? 'true' : 'false' }}"
-            :collaboration-key="{{ json_encode(env('COLLABORATION_ENABLED') ? $feedback->collaborationKey : null) }}">
+            :collaboration-key="{{ json_encode(config('app.collaboration.enabled') ? $feedback->collaborationKey : null) }}">
 
             <div>
                 <b-button variant="link" class="px-0 mr-3" href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $participant->id]) }}">

--- a/resources/views/includes/footer.blade.php
+++ b/resources/views/includes/footer.blade.php
@@ -1,7 +1,7 @@
 <footer class="page-footer text-center">
     <p class="footer-company-name">{{__('t.footer.slogan')}}
-        @if(env('APP_CONTACT_LINK') !== null && env('APP_CONTACT_LINK') !== "")
-        - <a href="{{env('APP_CONTACT_LINK')}}">{{env('APP_CONTACT_TEXT', __('t.footer.contact_text'))}}</a>
+        @if(config('app.contact.link') !== null && config('app.contact.link') !== "")
+        - <a href="{{config('app.contact.link')}}">{{config('app.contact.text', __('t.footer.contact_text'))}}</a>
         @endif
     </p>
 </footer>

--- a/resources/views/includes/footer.blade.php
+++ b/resources/views/includes/footer.blade.php
@@ -1,7 +1,7 @@
 <footer class="page-footer text-center">
     <p class="footer-company-name">{{__('t.footer.slogan')}}
         @if(config('app.contact.link') !== null && config('app.contact.link') !== "")
-        - <a href="{{config('app.contact.link')}}">{{config('app.contact.text', __('t.footer.contact_text'))}}</a>
+        - <a href="{{config('app.contact.link')}}">{{config('app.contact.text') ?? __('t.footer.contact_text')}}</a>
         @endif
     </p>
 </footer>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -24,7 +24,7 @@
     'routes' => collect(Route::getRoutes())->mapWithKeys(function (\Illuminate\Routing\Route $route) { return [$route->getName() => [ 'uri' => '/'.$route->uri(), 'method' => head($route->methods())]]; }),
     'csrf' => csrf_token(),
     'nonce' => app('csp-nonce'),
-    'signalingServers' => explode(' ', env('COLLABORATION_SIGNALING_SERVERS')),
+    'signalingServers' => explode(' ', config('app.collaboration.signaling_servers')),
     'username' => Auth::user() ? Auth::user()->name : null,
 ]) }}"></div>
 <script src="{{ mix('js/app.js') }}"></script>

--- a/tests/Feature/App/ReadWelcomePageTest.php
+++ b/tests/Feature/App/ReadWelcomePageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\App;
 
+use Illuminate\Support\Facades\Config;
 use Tests\TestCaseWithBasicData;
 
 class ReadWelcomePageTest extends TestCaseWithBasicData {
@@ -31,16 +32,17 @@ class ReadWelcomePageTest extends TestCaseWithBasicData {
 
     public function test_shouldDisplayContactWhenContactLinkSet(){
         // given
-        putenv("APP_CONTACT_LINK=mailto:test@test.ch");
+        Config::set('app.contact.link', 'mailto:test@test.ch');
         // when
         $response = $this->get('/course/' . $this->courseId);
         //then
         $response->assertOk();
         $response->assertSee(env('APP_CONTACT_TEXT', __('t.footer.contact_text')));
     }
+
     public function test_shouldNotDisplayContactWhenContactLinkNotSet(){
         // given
-        putenv("APP_CONTACT_LINK=");
+        Config::set('app.contact.link', '');
         // when
         $response = $this->get('/course/' . $this->courseId);
         //then


### PR DESCRIPTION
This allows to cache the config, as the .env file is not loaded when a cached config exists. See
https://laravel.com/docs/master/configuration#configuration-caching