### PR TITLE
alphabetical carousel switch in participant detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ##### Oktober 2022
 - Die Druckfunktion bei Rückmeldungen wurde überarbeitet. Es werden nun direkt fertige, konsistent gelayoutete PDF-Dateien heruntergeladen, anstatt dass man im Browser die PDF-Druck-Funktion verwenden muss. Da wir nun nicht mehr vom Verhalten unterschiedlicher Browser abhängig sind, konnten zudem die Seitenränder auf dem PDF verkleinert werden, um Papier zu sparen [#228](https://github.com/gloggi/qualix/issues/228)
+- Das Design des MiData-Login Buttons wurde ans neue PBS-Design angepasst. Merci @Sprudeel! [#265](https://github.com/gloggi/qualix/issues/265)
+- Neue Links zum einfachen Weiterspringen auf nächste und vorhergehende TN auf der TN-Detailansicht. Merci @Sprudeel! [#274](https://github.com/gloggi/qualix/issues/274)
+- Performance-Optimierungen für Qualix wurden ermöglicht. Merci @cleverer! [#44](https://github.com/gloggi/qualix/issues/44)
+- Bugfixes: Wenn ein Feature (konkret MiData-Login und WebRTC Synchronisierung) in einer Instanz von Qualix nicht konfiguriert ist, dann wird es komplett ausgeblendet / deaktiviert. Merci @cleverer! [#286](https://github.com/gloggi/qualix/pull/286) [#284](https://github.com/gloggi/qualix/pull/284)
 
 ##### September 2022
 - Die Ansichten "Blöcke" und "Spick" wurden kombiniert. Beobachtungsaufträge sind nun unter "Blöcke" verfügbar [#165](https://github.com/gloggi/qualix/issues/165)

--- a/app/Http/Controllers/ParticipantDetailController.php
+++ b/app/Http/Controllers/ParticipantDetailController.php
@@ -18,10 +18,14 @@ class ParticipantDetailController extends Controller {
      */
     public function index(Request $request, Course $course, Participant $participant) {
         $observations = $participant->observations->values();
+        $previousParticipant = $course->getPreviousCandidate($participant);
+        $nextParticipant = $course->getNextCandidate($participant);
 
         return view('participant-detail', [
             'participant' => $participant,
             'observations' => $observations,
+            'previousParticipant' => $previousParticipant,
+            'nextParticipant' => $nextParticipant,
             'feedbacks_using_observations' => $course->feedbacksUsingObservations($observations)
         ]);
     }

--- a/app/Http/Controllers/ParticipantDetailController.php
+++ b/app/Http/Controllers/ParticipantDetailController.php
@@ -18,8 +18,8 @@ class ParticipantDetailController extends Controller {
      */
     public function index(Request $request, Course $course, Participant $participant) {
         $observations = $participant->observations->values();
-        $previousParticipant = $course->getPreviousCandidate($participant);
-        $nextParticipant = $course->getNextCandidate($participant);
+        $previousParticipant = $course->getPreviousParticipant($participant);
+        $nextParticipant = $course->getNextParticipant($participant);
 
         return view('participant-detail', [
             'participant' => $participant,

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -206,4 +206,28 @@ class Course extends Model {
     public function getDefaultRequirementStatusIdAttribute() {
         return $this->requirement_statuses()->first('id')['id'] ?? null;
     }
+
+
+    /**
+     * Get the previous Participant in alphabetic order.
+     * 
+     * @param Participant $participant
+     */
+    public function getPreviousCandidate(Participant $participant) {
+        $participants = collect($this->participants)->toArray();
+        $index = array_search($participant->id, array_column($participants, 'id'));
+        return $index <= 0 ? false : $participants[$index -1];
+    }
+
+    /**
+     * Get the next Participant in alphabetic order.
+     * 
+     * @param Participant $participant
+     */
+    public function getNextCandidate(Participant $participant) {
+        $participants = collect($this->participants)->toArray();
+        $index = array_search($participant->id, array_column($participants, 'id'));
+        $length = count($participants);
+        return $index > $length-2 ? false : $participants[$index + 1];
+    }
 }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -209,25 +209,25 @@ class Course extends Model {
 
 
     /**
-     * Get the previous Participant in alphabetic order.
-     * 
+     * Get the previous participant in alphabetic order.
+     *
      * @param Participant $participant
      */
-    public function getPreviousCandidate(Participant $participant) {
-        $participants = collect($this->participants)->toArray();
+    public function getPreviousParticipant(Participant $participant) {
+        $participants = $this->participants->toArray();
         $index = array_search($participant->id, array_column($participants, 'id'));
         return $index <= 0 ? false : $participants[$index -1];
     }
 
     /**
-     * Get the next Participant in alphabetic order.
-     * 
+     * Get the next participant in alphabetic order.
+     *
      * @param Participant $participant
      */
-    public function getNextCandidate(Participant $participant) {
-        $participants = collect($this->participants)->toArray();
+    public function getNextParticipant(Participant $participant) {
+        $participants = $this->participants->toArray();
         $index = array_search($participant->id, array_column($participants, 'id'));
         $length = count($participants);
-        return $index > $length-2 ? false : $participants[$index + 1];
+        return $index >= $length-1 ? false : $participants[$index + 1];
     }
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -187,3 +187,7 @@
 .mh-1em {
     min-height: 1em;
 }
+
+.clear-both {
+    clear: both;
+}

--- a/resources/views/participant-detail.blade.php
+++ b/resources/views/participant-detail.blade.php
@@ -4,7 +4,10 @@
 
 @section('content')
 
+
     <b-card body-class="container-fluid">
+        @if($previousParticipant != false) <div class="float-left"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $previousParticipant['id']] ) }}">< {{ $previousParticipant['scout_name'] }}</a></div> @endif
+        @if($nextParticipant != false) <div class="float-right"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $nextParticipant['id']] ) }}">{{ $nextParticipant['scout_name'] }} ></a></div> @endif
         <template #header>{{__('t.views.participant_details.title')}}</template>
 
         <div class="row my-3">

--- a/resources/views/participant-detail.blade.php
+++ b/resources/views/participant-detail.blade.php
@@ -6,11 +6,12 @@
 
 
     <b-card body-class="container-fluid">
-        @if($previousParticipant != false) <div class="float-left"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $previousParticipant['id']] ) }}">< {{ $previousParticipant['scout_name'] }}</a></div> @endif
-        @if($nextParticipant != false) <div class="float-right"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $nextParticipant['id']] ) }}">{{ $nextParticipant['scout_name'] }} ></a></div> @endif
         <template #header>{{__('t.views.participant_details.title')}}</template>
 
-        <div class="row my-3">
+        @if($previousParticipant !== false) <div class="float-left"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $previousParticipant['id']] ) }}"><i class="fas fa-arrow-left"></i> {{ $previousParticipant['scout_name'] }}</a></div> @endif
+        @if($nextParticipant !== false) <div class="float-right"><a href="{{ route('participants.detail', ['course' => $course->id, 'participant' => $nextParticipant['id']] ) }}">{{ $nextParticipant['scout_name'] }} <i class="fas fa-arrow-right"></i></a></div> @endif
+
+        <div class="row my-3 clear-both">
 
             <div class="col-sm-12 col-md-6 col-lg-3 mb-3">
                 <div class="square-container">

--- a/tests/Unit/Models/CourseTest.php
+++ b/tests/Unit/Models/CourseTest.php
@@ -87,4 +87,55 @@ class CourseTest extends TestCaseWithBasicData {
         // then
         $this->assertEquals($expected, $defaultRequirementStatusId);
     }
+
+    public function test_getNextParticipant_returnsSecondParticipantForFirst() {
+        // given
+        $course = Course::find($this->courseId);
+        $first = $course->participants->first();
+        $second = $course->participants->get(1);
+
+        // when
+        $next = $course->getNextParticipant($first);
+
+        // then
+        $this->assertEquals($second, $next);
+    }
+
+    public function test_getNextParticipant_returnsNoParticipantForLast() {
+        // given
+        $course = Course::find($this->courseId);
+        $last = $course->participants->last();
+
+        // when
+        $next = $course->getNextParticipant($last);
+
+        // then
+        $this->assertEquals(false, $next);
+    }
+
+    public function test_getPreviousParticipant_returnsSecondToLastParticipantForLast() {
+        // given
+        $course = Course::find($this->courseId);
+        $participants = $course->participants;
+        $last = $participants->last();
+        $secondToLast = $participants->get(count($participants) - 2);
+
+        // when
+        $previous = $course->getPreviousParticipant($last);
+
+        // then
+        $this->assertEquals($secondToLast, $previous);
+    }
+
+    public function test_getPreviousParticipant_returnsNoParticipantForFirst() {
+        // given
+        $course = Course::find($this->courseId);
+        $first = $course->participants->first();
+
+        // when
+        $previous = $course->getPreviousParticipant($first);
+
+        // then
+        $this->assertEquals(false, $previous);
+    }
 }


### PR DESCRIPTION
This adds the possibility to go to the next and previous user of the cours in alphabetical order when viewing `participant-detail.blade.php`

It looks like this:
![back](https://user-images.githubusercontent.com/79663902/193429989-c49c56a9-5e78-4354-b7b1-d40eeef63af0.png)

This closes #274 
