### PR TITLE
More flexible deploy-scripts for other deployments

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: .
 
+  app-name:
+    description: 'The App Name'
+    required: false
+    default: ''
+
   app-env:
     description: 'The environment type that will be deployed'
     required: false
@@ -147,6 +152,7 @@ runs:
         SSH_USERNAME: ${{ inputs.ssh-username }}
         SSH_HOST: ${{ inputs.ssh-host }}
         SSH_DIRECTORY: ${{ inputs.ssh-directory }}
+        APP_NAME: ${{ inputs.app-name }}
         APP_ENV: ${{ inputs.app-env }}
         APP_KEY: ${{ inputs.app-key }}
         APP_DEBUG: ${{ inputs.app-debug }}

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -73,7 +73,7 @@ ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   cd $SSH_DIRECTORY
   php -r "if(PHP_VERSION_ID<${PHP_MIN_VERSION_ID:-80100}){echo \"Your PHP version is too old\\nYou might be able to use these instructions on your hosting as well: https://www.cyon.ch/support/a/php-standardversion-fur-die-kommandozeile-festlegen\n\";exit(1);}"
 
-  php artisan down
+  php artisan down --render=updating
 EOF
 
 echo "Uploading files to the server..."

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -62,12 +62,12 @@ ssh-keyscan -H $SSH_HOST
 echo "Showing configured know_hosts:"
 cat ~/.ssh/known_hosts
 
-echo "Checking PHP version:"
+echo "Checking PHP version:"c
 ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   set -e
   php -v
   cd $SSH_DIRECTORY
-  php -r "if(PHP_VERSION_ID<${PHP_MIN_VERSION_ID:-80100}){echo \"Your PHP version is too old\\n\";exit(1);}"
+  php -r "if(PHP_VERSION_ID<${PHP_MIN_VERSION_ID:-80100}){echo \"Your PHP version is too old\\nYou might be able to use these instructions on your hosting as well: https://www.cyon.ch/support/a/php-standardversion-fur-die-kommandozeile-festlegen\n\";exit(1);}"
 EOF
 
 echo "Uploading files to the server..."

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -56,17 +56,19 @@ docker-compose run --no-deps --entrypoint "/bin/sh -c 'npm install && npm run pr
 docker-compose run --no-deps --entrypoint "composer install --no-dev" qualix
 PHP_MIN_VERSION_ID=$(grep -Po '(?<=\(PHP_VERSION_ID >= )[0-9]+(?=\))' vendor/composer/platform_check.php)
 
+echo "Scanning ssh host keys of \"$SSH_HOST\" (showing hashed output only):"
+ssh-keyscan -H $SSH_HOST
+
+echo "Showing configured know_hosts:"
 cat ~/.ssh/known_hosts
 
-echo "Checking PHP version"
-ssh -l $SSH_USERNAME -T $SSH_HOST -o StrictHostKeyChecking=no <<EOF
+echo "Checking PHP version:"
+ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   set -e
   php -v
   cd $SSH_DIRECTORY
   php -r "if(PHP_VERSION_ID<${PHP_MIN_VERSION_ID:-80100}){echo \"Your PHP version is too old\\n\";exit(1);}"
 EOF
-
-cat ~/.ssh/known_hosts
 
 echo "Uploading files to the server..."
 lftp <<EOF

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -4,6 +4,10 @@ set -e
 rm -f .env
 cp .env.example .env
 
+if [ "$APP_NAME" != "" ]; then
+  sed -ri "s~^#APP_NAME=.*$~APP_NAME=$APP_NAME~" .env
+fi
+
 sed -ri "s~^APP_ENV=.*$~APP_ENV=$APP_ENV~" .env
 sed -ri "s~^APP_KEY=.*$~APP_KEY=$APP_KEY~" .env
 sed -ri "s~^APP_DEBUG=.*$~APP_DEBUG=$APP_DEBUG~" .env

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -10,7 +10,7 @@ sed -ri "s~^APP_DEBUG=.*$~APP_DEBUG=$APP_DEBUG~" .env
 sed -ri "s~^APP_URL=.*$~APP_URL=$APP_URL~" .env
 sed -ri "s~^APP_CONTACT_LINK=.*$~APP_CONTACT_LINK=$APP_CONTACT_LINK~" .env
 
-if [ "$APP_CONTACT_TEXT" != ""]; then
+if [ "$APP_CONTACT_TEXT" != "" ]; then
   sed -ri "s~^#APP_CONTACT_TEXT=.*$~APP_CONTACT_TEXT=$APP_CONTACT_TEXT~" .env
 fi
 

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -68,6 +68,8 @@ ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   php -v
   cd $SSH_DIRECTORY
   php -r "if(PHP_VERSION_ID<${PHP_MIN_VERSION_ID:-80100}){echo \"Your PHP version is too old\\nYou might be able to use these instructions on your hosting as well: https://www.cyon.ch/support/a/php-standardversion-fur-die-kommandozeile-festlegen\n\";exit(1);}"
+
+  php artisan down
 EOF
 
 echo "Uploading files to the server..."
@@ -90,4 +92,6 @@ ssh -l $SSH_USERNAME -T $SSH_HOST <<EOF
   php artisan config:cache
   php artisan route:cache
   php artisan view:cache
+
+  php artisan up
 EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_TRACKING_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        if: env.SENTRY_AUTH_TOKEN != null
         with:
           environment: ${{ needs.get-environment-name.outputs.environment }}
           projects: ${{ secrets.SENTRY_PROJECTS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
     steps:
 
       - uses: peter-evans/repository-dispatch@v1
+        env:
+          REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        if: env.REPO_ACCESS_TOKEN != null
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           event-type: ci-passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           ssh-username: ${{ secrets.SSH_USERNAME }}
           ssh-host: ${{ secrets.SSH_HOST }}
           ssh-directory: ${{ secrets.SSH_DIRECTORY }}
+          app-name: ${{ secrets.APP_NAME }}
           app-key: ${{ secrets.APP_KEY }}
           app-url: ${{ secrets.APP_URL }}
           app-contact-link: ${{ secrets.APP_CONTACT_LINK }}

--- a/resources/views/updating.blade.php
+++ b/resources/views/updating.blade.php
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Qualix - Update / mise à jour</title>
+
+    <style>
+        html, body {
+            background-color: #fff;
+            color: #636b6f;
+            font-family: 'Source Sans Pro', sans-serif;
+            font-weight: 100;
+            height: 100vh;
+            margin: 0;
+        }
+
+        .full-height {
+            height: 100vh;
+        }
+
+        .flex-center {
+            align-items: center;
+            display: flex;
+            justify-content: center;
+        }
+
+        .position-ref {
+            position: relative;
+        }
+
+        .code {
+            border-right: 1px solid #a7abad;
+            font-size: 26px;
+            padding: 0 15px 0 15px;
+            text-align: center;
+        }
+
+        .message {
+            font-size: 18px;
+            text-align: center;
+            padding: 10px;
+            color: #2c3135;
+        }
+    </style>
+</head>
+<body>
+<div class="flex-center position-ref full-height">
+    <div class="code">503</div>
+    <div class="message">
+        <p>
+        Qualix wird gerade aktualisiert. Bitte einen Moment Geduld.
+        @if($_ENV['APP_CONTACT_LINK'] !== null && $_ENV['APP_CONTACT_LINK'] !== "")
+            Falls diese Nachricht unerwartet erscheint, <a href="{{$_ENV['APP_CONTACT_LINK']}}">kontaktiere uns</a>.
+        @endif
+        </p>
+        <p>
+        Qualix est en cours de mise à jour. Veuille patienter un instant.
+        @if($_ENV['APP_CONTACT_LINK'] !== null && $_ENV['APP_CONTACT_LINK'] !== "")
+                Si ce message apparaît de manière inattendue, <a href="{{$_ENV['APP_CONTACT_LINK']}}">contacte-nous</a>.
+        @endif
+        </p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
I'm addressing 3 issues with this PR:
- reenable ssh strict host checking. @carlobeltrame I actually got it working by just copying the hashed ssh-keyscan output form a failed run. The only difference seems to be the order of the keys and their hashed hostnames. But the keys themselves are the same as when I do the keyscan locally…
- ~~I removed the failing php version check, as this does not work with cyon, as they have a different php version for the bare `php` cli command and the actual running php version.~~  
    I changed the php version check error message to include a hint on how one might solve the cli problem… 
- I adjusted the CI Trigger action step, so it doesn't fail if no `REPO_ACCESS_TOKEN` is configured…
- Added some commands to the deploy script to put qualix in maintenance mode automatically (resolves #279)
- I adjusted the sentry action step, so it doesn't fail if no `env.SENTRY_AUTH_TOKEN` is configured…
- Fixed typo in deploy script, which prevented `APP_CONTACT_TEXT` from working
- Allow to set `APP_NAME` in CI