### PR TITLE
Simplify creating multiple consecutive observations in the same block

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,13 +7,10 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install libxml2-dev li
 RUN echo "de_CH.UTF-8 UTF-8" >> /etc/locale.gen && echo "fr_CH.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
-RUN yes | pecl install xdebug-3.2.0 && docker-php-ext-enable xdebug
-ENV XDEBUG_MODE="debug,develop"
-ENV XDEBUG_CONFIG="client_host=docker-host"
-
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions xdebug @composer
 RUN docker-php-ext-install pdo pdo_mysql mbstring xml bcmath zip gd
+COPY docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 RUN a2enmod rewrite
 COPY apache-vhost.conf /etc/apache2/sites-enabled/000-default.conf

--- a/.docker/docker-php-ext-xdebug.ini
+++ b/.docker/docker-php-ext-xdebug.ini
@@ -1,0 +1,5 @@
+[xdebug]
+zend_extension=xdebug.so
+xdebug.mode=develop,debug
+xdebug.client_host = "host.docker.internal"
+xdebug.idekey="PHPSTORM"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##### März 2024
+- Nachdem man via Blöcke-Ansicht eine Beobachtung hinzugefügt hat, bleibt man nun auf dem Beobachtungs-Formular, um noch weitere Beobachtungen erfassen zu können. Das vorherige Verhalten war noch aus der Zeit als der Spick und die Blöcke-Ansicht noch separat waren, und war für Beobachtungsaufträge mit genau einer Beobachtung pro Auftrag optimiert. Das neue Verhalten ist hoffentlich hilfreicher, um mehrere kleine Beobachtungen zu erfassen [#334](https://github.com/gloggi/qualix/pull/334)
+
 ##### Februar 2024
 - Qualix enthält neu ein Namenslernspiel! Auf der TN-Liste hat es einen Link zum Spiel [#332](https://github.com/gloggi/qualix/pull/332)
 

--- a/app/Http/Controllers/BlockListController.php
+++ b/app/Http/Controllers/BlockListController.php
@@ -22,7 +22,6 @@ class BlockListController extends Controller
     public function crib(Request $request, Course $course, User $user)
     {
         $userId = $user->id ?? Auth::id();
-        $request->session()->flash('return_url', $request->url());
         return view('crib', [
             'blockManagementLink' => $this->blockManagementLink($course, 't.views.crib.here'),
             'showObservationAssignments' => $course->observationAssignments()->count(),

--- a/app/Http/Controllers/ObservationController.php
+++ b/app/Http/Controllers/ObservationController.php
@@ -95,7 +95,6 @@ class ObservationController extends Controller {
      */
     protected function rememberPreviouslyActiveView(Request $request) {
         $returnTo = $this->extractPathParameter(URL::previous(), 'participants.detail', 'participant');
-        $request->session()->keep(['return_url']);
         $request->session()->flash('participant_before_edit', $request->session()->get('participant_before_edit', $returnTo));
     }
 
@@ -110,8 +109,6 @@ class ObservationController extends Controller {
      * @return RedirectResponse
      */
     protected function redirectToPreviouslyActiveView(Request $request, Course $course, Collection $returnOptions, $fallback = null) {
-        if ($request->session()->has('return_url')) return Redirect::to($request->session()->get('return_url'));
-
         $returnTo = $request->session()->get('participant_before_edit');
         if (!$returnOptions->contains($returnTo)) {
             $returnTo = $returnOptions->first();

--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -115,7 +115,6 @@ class ParticipantController extends Controller
      */
     protected function rememberPreviouslyActiveView(Request $request) {
         $returnTo = $this->extractPathParameter(URL::previous(), 'participants.detail', 'participant');
-        $request->session()->keep(['return_url']);
         $request->session()->flash('participant_before_edit', $request->session()->get('participant_before_edit', $returnTo));
     }
 
@@ -130,8 +129,6 @@ class ParticipantController extends Controller
      * @return RedirectResponse
      */
     protected function redirectToPreviouslyActiveView(Request $request, Course $course) {
-        if ($request->session()->has('return_url')) return Redirect::to($request->session()->get('return_url'));
-
         $returnTo = $request->session()->get('participant_before_edit');
         if ($returnTo) return Redirect::to(route('participants.detail', ['course' => $course->id, 'participant' => $returnTo]));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - .:/var/www
       - ./public/.htaccess.docker:/var/www/public/.htaccess
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   db:
     image: mariadb:10.3

--- a/tests/Feature/Crib/ReadCribTest.php
+++ b/tests/Feature/Crib/ReadCribTest.php
@@ -191,7 +191,7 @@ class ReadCribTest extends TestCaseWithCourse {
 
     }
 
-    public function test_shouldReturnToCrib_afterAddingObservationInAssignment() {
+    public function test_shouldReturnToObservationForm_afterAddingObservationInAssignment() {
         // given
         $block1 = $this->createBlock('Block 1', '1.1', '01.01.2019');
         $block2 = $this->createBlock('Block 2', '1.2', '01.01.2019');
@@ -218,10 +218,10 @@ class ReadCribTest extends TestCaseWithCourse {
 
         // then
         $response->assertStatus(302);
-        $response->assertRedirect('/course/' . $this->courseId . '/crib');
+        $response->assertRedirect('/course/' . $this->courseId . '/observation/new?participant=' . $participant1 . '&block=' . $block1);
     }
 
-    public function test_shouldReturnToCrib_afterAddingObservationInBlock() {
+    public function test_shouldReturnToObservationForm_afterAddingObservationInBlock() {
         // given
         $block1 = $this->createBlock('Block 1', '1.1', '01.01.2019');
         $participant1 = $this->createParticipant('One');
@@ -241,6 +241,6 @@ class ReadCribTest extends TestCaseWithCourse {
 
         // then
         $response->assertStatus(302);
-        $response->assertRedirect('/course/' . $this->courseId . '/crib');
+        $response->assertRedirect('/course/' . $this->courseId . '/observation/new?participant=' . $participant1 . '&block=' . $block1);
     }
 }


### PR DESCRIPTION
Fixes #311

The previous behaviour was built in a time when crib and block list were two separate views. It also was optimized for fulfilling a observation assignment by creating a single observation. Hopefully the new behaviour helps to create multiple small observations.