### PR TITLE
Eingeladene E-Mail-Adresse via DNS überprüfen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+##### Mai 2025
+- Beim Einladen von Leuten in den Kurs wird die eingegebene E-Mail-Adresse strenger auf Fehler überprüft [#141](https://github.com/gloggi/qualix/issues/141)
+
 ##### März 2025
-- Neu können Blöcke aus eCamp v3 importiert werden. [#370](https://github.com/gloggi/qualix/pull/370)
+- Neu können Blöcke aus eCamp v3 importiert werden [#370](https://github.com/gloggi/qualix/pull/370)
 
 ##### August 2024
 - Neu können Beurteilungsraster in Qualix erstellt und ausgefüllt werden. Beurteilungsraster sind detaillierte Kriterienkataloge, mithilfe deren man eine komplexe Leistung von TN fair und objektiv beurteilen kann. Im Kursadmin-Bereich kann man Beurteilungsraster entwerfen / zusammenstellen (d.h. die Kriterien im Katalog definieren). Der so zusammengestellte Fragebogen kann dann - für eine spezifische Leistung von 1 oder mehreren TN - entweder direkt in Qualix digital ausgefüllt werden, oder ausgedruckt und von Hand ausgefüllt werden [#343](https://github.com/gloggi/qualix/issues/343)

--- a/app/Http/Requests/InvitationRequest.php
+++ b/app/Http/Requests/InvitationRequest.php
@@ -13,7 +13,7 @@ class InvitationRequest extends FormRequest {
      */
     public function rules() {
         return [
-            'email' => 'required|email|max:50',
+            'email' => 'required|email:strict,Egulias\EmailValidator\Validation\DNSCheckValidation|max:50',
         ];
     }
 

--- a/cypress/e2e/invite.cy.js
+++ b/cypress/e2e/invite.cy.js
@@ -34,15 +34,15 @@ describe('invitation flow', () => {
 
   it('successfully invites another equipe member', () => {
     cy.get('#email')
-      .type('some-email@example.org')
+      .type('some-email@gmail.com')
     cy.contains('Einladen')
       .click()
 
-    cy.contains('Wir haben eine Einladung an some-email@example.org gesendet.')
+    cy.contains('Wir haben eine Einladung an some-email@gmail.com gesendet.')
 
     cy.logout()
 
-    cy.login({ email: 'some-email@example.org' })
+    cy.login({ email: 'some-email@gmail.com' })
 
     cy.lastSentMail()
       .then(mail => {
@@ -51,7 +51,7 @@ describe('invitation flow', () => {
         cy.visit(verifyLink)
 
         cy.get('.card-header').contains('Einladung in ')
-        cy.contains('Gehört dir die Mailadresse some-email@example.org?')
+        cy.contains('Gehört dir die Mailadresse some-email@gmail.com?')
 
         cy.contains('Nein, diese Einladung ist nicht für mich')
           .should('have.attr', 'href').and('match', /^http:\/\/qualix$/)
@@ -67,20 +67,20 @@ describe('invitation flow', () => {
 
   it('deletes an invitation', () => {
     cy.get('#email')
-      .type('some-email@example.org')
+      .type('some-email@gmail.com')
     cy.contains('Einladen')
       .click()
 
-    cy.contains('Wir haben eine Einladung an some-email@example.org gesendet.')
+    cy.contains('Wir haben eine Einladung an some-email@gmail.com gesendet.')
 
     cy.contains('Einladungen').parent('.card').find('[title="Löschen"]').click()
 
-    cy.contains('Willst du die Einladung für some-email@example.org wirklich entfernen?')
+    cy.contains('Willst du die Einladung für some-email@gmail.com wirklich entfernen?')
       .parent()
       .contains('Löschen')
       .click()
 
-    cy.contains('Die Einladung für some-email@example.org wurde erfolgreich gelöscht.')
+    cy.contains('Die Einladung für some-email@gmail.com wurde erfolgreich gelöscht.')
 
     cy.contains('Momentan sind keine Einladungen offen.')
   })

--- a/tests/Feature/Admin/Course/DeleteCourseTest.php
+++ b/tests/Feature/Admin/Course/DeleteCourseTest.php
@@ -20,6 +20,8 @@ class DeleteCourseTest extends TestCaseWithBasicData {
 
     public function setUp(): void {
         parent::setUp();
+
+        $this->fakeDNSValidation();
     }
 
     public function test_shouldRequireLogin() {

--- a/tests/Feature/Admin/Equipe/AcceptInvitationTest.php
+++ b/tests/Feature/Admin/Equipe/AcceptInvitationTest.php
@@ -18,6 +18,8 @@ class AcceptInvitationTest extends TestCaseWithCourse {
     public function setUp(): void {
         parent::setUp();
 
+        $this->fakeDNSValidation();
+
         $payload = ['email' => $this->email];
         $this->post('/course/' . $this->courseId . '/admin/invitation', $payload);
         $this->token = Invitation::where('course_id', '=', $this->courseId)->where('email', '=', $payload['email'])->first()->token;

--- a/tests/Feature/Admin/Equipe/CreateInvitationTest.php
+++ b/tests/Feature/Admin/Equipe/CreateInvitationTest.php
@@ -17,6 +17,8 @@ class CreateInvitationTest extends TestCaseWithCourse {
         parent::setUp();
 
         $this->payload = ['email' => 'neues-mitglied@equipe.com'];
+
+        $this->fakeDNSValidation();
     }
 
     public function test_shouldRequireLogin() {
@@ -108,6 +110,21 @@ class CreateInvitationTest extends TestCaseWithCourse {
         // given
         $payload = $this->payload;
         $payload['email'] = 'so en chabis';
+
+        // when
+        $response = $this->post('/course/' . $this->courseId . '/admin/invitation', $payload);
+
+        // then
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        /** @var ValidationException $exception */
+        $exception = $response->exception;
+        $this->assertEquals('E-Mail muss eine gültige E-Mail-Adresse sein.', $exception->validator->errors()->first('email'));
+    }
+
+    public function test_shouldValidateNewInvitationData_emailWithNonexistentMailserver() {
+        // given
+        $payload = $this->payload;
+        $payload['email'] = 'chabis@fail.com';
 
         // when
         $response = $this->post('/course/' . $this->courseId . '/admin/invitation', $payload);

--- a/tests/Feature/Admin/Equipe/DeleteInvitationTest.php
+++ b/tests/Feature/Admin/Equipe/DeleteInvitationTest.php
@@ -11,6 +11,8 @@ class DeleteInvitationTest extends TestCaseWithCourse {
     public function setUp(): void {
         parent::setUp();
 
+        $this->fakeDNSValidation();
+
         $this->post('/course/' . $this->courseId . '/admin/invitation', ['email' => $this->email]);
     }
 

--- a/tests/TestCaseWithCourse.php
+++ b/tests/TestCaseWithCourse.php
@@ -8,6 +8,8 @@ use App\Models\Course;
 use App\Models\FeedbackData;
 use App\Models\Participant;
 use App\Models\Requirement;
+use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
 
 abstract class TestCaseWithCourse extends TestCase
 {
@@ -42,5 +44,18 @@ abstract class TestCaseWithCourse extends TestCase
         if (!$course->participants()->exists()) $this->createParticipant('Feedback-TN', $course->id);
         $feedbackData = FeedbackData::create(['name' => $name, 'course_id' => $course->id]);
         return $feedbackData->feedbacks()->create(['participant_id' => $course->participants()->first()->id])->id;
+    }
+
+    protected function fakeDNSValidation() {
+        $this->app->bind(DNSCheckValidation::class, TestDNSCheckValidation::class);
+    }
+}
+
+class TestDNSCheckValidation extends DNSCheckValidation {
+    /**
+     * In this test, we want the DNS validation to fail for fail.com domains, and pass for all others.
+     */
+    public function isValid(string $email, EmailLexer $emailLexer): bool {
+        return !str_ends_with($email, 'fail.com');
     }
 }


### PR DESCRIPTION
Fixes #141 
Das wird nicht alle nichtexistenten E-Mails vermeiden, aber wenigstens solche die nicht einmal zu einem gültigen Mailserver gesendet werden.
Die E2E-Tests für die Invitations funktionieren jetzt nur noch, wenn man eine Internetverbindung hat (um via DNS die eingegebene Mailadresse zu prüfen), aber bei E2E soll es ja auch möglichst realistisch sein.