### PR TITLE
Balance feedback allocations according to trainer capacities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ##### Juli 2026
 - Auf einer Beobachtung können neu mehrere beobachtende Personen hinterlegt werden [#293](https://github.com/gloggi/qualix/issues/293)
 - Das Profilbild von TN und des eigenen Accounts kann neu entfernt werden [#336](https://github.com/gloggi/qualix/issues/336)
-- Bugfix: Im Namenslernspiel wird beim Modus "Einfach (multiple choice)" nun auch dann ein Punkt vergeben, wenn mehrere TN im Kurs gleich heissen und man auf die andere gleichnamige Option klickt. Im Modus "Schwierig (Namen eintippen)" zählt neu auch ein ohne Umlaut/Akzent eingetippter Name (z.B. "Muller" statt "Müller") als richtig [#382](https://github.com/gloggi/qualix/issues/382)
+- Im Namenslernspiel wird beim Modus "Einfach (multiple choice)" nun auch dann ein Punkt vergeben, wenn mehrere TN im Kurs gleich heissen und man auf die andere gleichnamige Option klickt. Im Modus "Schwierig (Namen eintippen)" zählt neu auch ein ohne Umlaut/Akzent eingetippter Name (z.B. "Muller" statt "Müller") als richtig [#382](https://github.com/gloggi/qualix/issues/382)
+- Die automatische Zuteilungsgenerierung für Rückmeldungen verteilt die Rückmeldungen bei gleichwertigen Wünschen jetzt gleichmässiger auf die Equipe, statt zuerst die ersten Equipenmitglieder bis zur Kapazitätsgrenze zu füllen [#394](https://github.com/gloggi/qualix/issues/394)
 
 ##### Juli 2025
 - In Rückmeldungen kann die Zuteilung der TN zu den Equipenmitgliedern jetzt basierend auf Wünschen und Kapazitäten von Equipe und TN automatisch generiert werden. Dazu kann man unter Kursadmin -> Rückmeldungen auf einer bereits erstellten Rückmeldung auf das neue Icon "Zuteilung generieren" klicken [#260](https://github.com/gloggi/qualix/issues/260)

--- a/CHANGELOG_fr.md
+++ b/CHANGELOG_fr.md
@@ -3,7 +3,8 @@
 ##### Juillet 2026
 - Il est désormais possible d'indiquer plusieurs personnes ayant observé pour une même observation [#293](https://github.com/gloggi/qualix/issues/293)
 - Il est désormais possible de supprimer la photo de profil d'un-e TN ou de sa propre personne [#336](https://github.com/gloggi/qualix/issues/336)
-- Correction de bug : Dans le jeu des noms, en mode "Facile (choix multiple)", un point est désormais attribué même si plusieurs participant·e·s du cours portent le même nom et que l'on clique sur l'autre option portant ce nom. En mode "Difficile (saisir le nom)", un nom saisi sans accent (par ex. "Muller" au lieu de "Müller") est désormais aussi compté comme correct [#382](https://github.com/gloggi/qualix/issues/382)
+- Dans le jeu des noms, en mode "Facile (choix multiple)", un point est désormais attribué même si plusieurs participant·e·s du cours portent le même nom et que l'on clique sur l'autre option portant ce nom. En mode "Difficile (saisir le nom)", un nom saisi sans accent (par ex. "Muller" au lieu de "Müller") est désormais aussi compté comme correct [#382](https://github.com/gloggi/qualix/issues/382)
+- La génération automatique de l'attribution des évaluations répartit désormais les évaluations de manière plus équilibrée au sein de l'équipe en cas de souhaits équivalents, au lieu de remplir d'abord les premiers membres de l'équipe jusqu'à leur capacité maximale [#394](https://github.com/gloggi/qualix/issues/394)
 
 ##### Juillet 2025
 - Dans les évaluations, l'attribution des participant-e-s aux membres de l'équipe peut désormais être générée automatiquement en fonction des souhaits et des capacités de l'équipe et des participant-e-s. Pour cela, il suffit de cliquer sur la nouvelle icône "Générer l'attribution" sur une évaluation déjà créée, sous Administration -> Évaluations [#260](https://github.com/gloggi/qualix/issues/260)

--- a/app/Services/FeedbackAllocation/DefaultFeedbackAllocator.php
+++ b/app/Services/FeedbackAllocation/DefaultFeedbackAllocator.php
@@ -45,6 +45,14 @@ class DefaultFeedbackAllocator implements FeedbackAllocator {
         $preferenceMatrix = array_fill(0, $participantCount, array_fill(0, $trainerCount, $defaultPriority));
 
         // Add trainers to the sink with capacity
+        // graphp's min-cost-flow solver doesn't support parallel edges between the same
+        // vertex pair, so each capacity unit gets its own intermediate vertex: trainer -> unit
+        // -> sink. The unit -> sink edges have cost increasing proportionally to how busy the
+        // trainer already is (i / capacity), so otherwise-tied assignments prefer the
+        // least-full trainer, balancing the load instead of filling earlier trainers first.
+        // The fractional cost is always < 1, so it can never override a real preference-cost
+        // difference (which always differs by at least 1).
+        $nextUnitVertexId = $participantCount + $trainerCount + 2;
         foreach ($trainerCapacities as $index => $trainer) {
             [$name, $capacity] = $trainer;
             $trainerVertexId = $participantCount + $index + 2;
@@ -53,7 +61,11 @@ class DefaultFeedbackAllocator implements FeedbackAllocator {
             $this->trainerNameToVertexId[$name] = $trainerVertexId;
             $this->vertexIdToName[$trainerVertexId] = $name;
 
-            $this->addEdge($trainerVertex, $this->sink, $capacity, 0);
+            for ($unit = 0; $unit < $capacity; $unit++) {
+                $unitVertex = $this->graph->createVertex($nextUnitVertexId++);
+                $this->addEdge($trainerVertex, $unitVertex, 1, 0);
+                $this->addEdge($unitVertex, $this->sink, 1, $unit / $capacity);
+            }
         }
 
         // Add source to participants and handle preferences
@@ -99,7 +111,7 @@ class DefaultFeedbackAllocator implements FeedbackAllocator {
         }
     }
 
-    private function addEdge(Vertex $from, Vertex $to, int $capacity, int $cost) {
+    private function addEdge(Vertex $from, Vertex $to, int $capacity, int|float $cost) {
         $edge = $this->graph->createEdgeDirected($from, $to);
         $edge->setWeight($cost);
         $edge->setCapacity($capacity);
@@ -148,29 +160,23 @@ class DefaultFeedbackAllocator implements FeedbackAllocator {
 
     private function getAssignments(Graph $resultGraph): array {
         $assignments = [];
-        $trainerParticipants = [];
 
-        $sinkId = $this->sink->getId();
-        $edgesToSink = $resultGraph->getVertex($sinkId)->getEdgesIn();
-        foreach ($edgesToSink as $edge) {
-            $trainerVertex = $edge->getVertexStart();
-            $trainerName = $this->vertexIdToName[$trainerVertex->getId()];
+        foreach ($this->trainerNameToVertexId as $trainerName => $trainerVertexId) {
+            $trainerVertex = $resultGraph->getVertex($trainerVertexId);
+            $participants = [];
             foreach ($trainerVertex->getEdgesIn() as $edgeIn) {
-                $vertexIn = $edgeIn->getVertexStart();
-                if ($vertexIn->getId() !== $sinkId && $edgeIn->getFlow() > 0) {
-                    $participantName = $this->vertexIdToName[$vertexIn->getId()];
-                    $trainerParticipants[$trainerName][] = $participantName;
+                if ($edgeIn->getFlow() > 0) {
+                    $participants[] = $this->vertexIdToName[$edgeIn->getVertexStart()->getId()];
                 }
             }
-
+            if ($participants) {
+                $assignments[] = [
+                    'trainerIdent' => $trainerName,
+                    'participantIdents' => $participants
+                ];
+            }
         }
 
-        foreach ($trainerParticipants as $trainerName => $participants) {
-            $assignments[] = [
-                'trainerIdent' => $trainerName,
-                'participantIdents' => $participants
-            ];
-        }
         return $assignments;
     }
 }

--- a/docs/Features/25 Feedback Allocation Algorithm.md
+++ b/docs/Features/25 Feedback Allocation Algorithm.md
@@ -42,20 +42,25 @@ flowchart LR
     P3 -->|"cost=1"| T1
     P3 -->|"cost=100"| T2
 
-    T1 -->|"cap=2, cost=0"| K
-    T2 -->|"cap=1, cost=0"| K
+    T1 -->|"cap=1, cost=0"| U1["unit 1/2"]
+    T1 -->|"cap=1, cost=0"| U2["unit 2/2"]
+    T2 -->|"cap=1, cost=0"| U3["unit 1/1"]
+
+    U1 -->|"cost=0"| K
+    U2 -->|"cost=0.5"| K
+    U3 -->|"cost=0"| K
 ```
 
-The middle layer is bipartite: in principle every participant connects to every trainer (`cap=1`, `cost` = that pairing's priority). Here participant 1 has **no** edge to trainer B — that pairing is forbidden, so no edge is created and the assignment can never route through it. The min-cost flow picks one outgoing edge per participant so that trainer capacities (`trainer A` ≤ 2, `trainer B` ≤ 1) hold and the total cost — i.e. the sum of granted-wish priorities — is minimal.
+In principle, every participant connects to every trainer (`cap=1`, `cost` = that pairing's priority). Here participant 1 has **no** edge to trainer B — that pairing is forbidden, so no edge is created and the assignment can never route through it. The min-cost flow picks one outgoing edge per participant so that trainer capacities (`trainer A` ≤ 2, `trainer B` ≤ 1) hold and the total cost — i.e. the sum of granted-wish priorities — is minimal.
 
 - **Source** (vertex `0`, balance `+N`) and **sink** (vertex `1`, balance `−N`), where `N` = participant count. This forces a flow of exactly `N` units — one per participant.
 - **Source → participant**: capacity `1`, cost `0`. Each participant sends exactly one unit of flow (gets exactly one trainer).
-- **Trainer → sink**: capacity = the trainer's `capacity`, cost `0`. Caps how many feedbacks a trainer receives.
 - **Participant → trainer**: capacity `1`, cost = the pairing's priority. Costs are held in a `preferenceMatrix` initialized to `defaultPriority` for every pair, then:
   - each of a participant's ranked wishes lowers the cost for that trainer to `min(currentCost, weight)`, where `weight` is the wish rank (`priority`, 1 = top wish) — or `1` when `unweighted`. Lower cost = more preferred.
   - forbidden pairings are set to `PHP_INT_MAX` and **no edge** is created for them, making the assignment impossible.
+- **Trainer → unit → sink**: each trainer's `capacity` is split into `capacity` unit vertices (`trainer → unit`: `cap=1, cost=0`; `unit → sink`: `cap=1`, cost = `unitIndex / capacity`, 0-indexed). This makes the *marginal* cost of the trainer's `k`-th assignment grow with how busy the trainer already is (proportionally, not in absolute terms — a trainer with capacity 4 and one already assigned is *less* busy, and thus cheaper to assign to next, than a trainer with capacity 2 and one already assigned). Since these per-unit costs are always `< 1` and real preference costs are integers that differ by at least `1`, this can only break ties between otherwise equally-good trainers — it never overrides a genuine wish/default priority difference. It's implemented with per-unit intermediate vertices rather than parallel `trainer → sink` edges because `graphp`'s min-cost-flow solver doesn't support parallel edges between the same vertex pair.
 
-Vertex IDs are laid out deterministically: participants at `index + 2`, trainers at `participantCount + index + 2`, with lookup maps between vertex IDs and the original trainer/participant identifiers.
+Vertex IDs are laid out deterministically: participants at `index + 2`, trainers at `participantCount + index + 2`, and the per-trainer unit vertices following after all trainers, with lookup maps between vertex IDs and the original trainer/participant identifiers (unit vertices are purely internal — assignments are read back directly off each trainer vertex's incoming edges, see `getAssignments`, so they never need a name lookup).
 
 ### Solving (`calculateMaxFlowMinCost`)
 

--- a/tests/Unit/Services/FeedbackAllocation/FeedbackAllocatorTest.php
+++ b/tests/Unit/Services/FeedbackAllocation/FeedbackAllocatorTest.php
@@ -46,10 +46,12 @@ class FeedbackAllocatorTest extends TestCase
 
     public function test_UnweightedFeedbackAllocation()
     {
-        $trainerCapacities = [['Alice', 2], ['Bob', 2]];
+        $trainerCapacities = [['Alice', 4], ['Bob', 4]];
         $participantWishes = [
             ['John', 'Alice', 'Bob'], // John prefers Alice or Bob
-            ['Jane', 'Bob', 'Alice']  // Jane prefers Bob or Alice
+            ['Jane', 'Bob', 'Alice'], // Jane prefers Bob or Alice
+            ['Jake', 'Alice', 'Bob'], // Jake prefers Alice or Bob
+            ['Jack', 'Alice', 'Bob']  // Jack prefers Alice or Bob
         ];
         $numberOfWishes = 2;
         $forbiddenWishes = [];
@@ -65,19 +67,51 @@ class FeedbackAllocatorTest extends TestCase
         );
 
         $expected = [
-            // In the unweighted case, the wishes [Alice, Bob] and [Bob, Alice] are considered the same.
-            // So by default, the algorithm assigns as many participants as it can to the first trainer.
+            // In the unweighted case, the wishes [Alice, Bob] and [Bob, Alice] are considered the same,
+            // so both trainers are equally good for all 3 participants. The allocator balances the load
+            // in this case instead of filling up the first trainer before assigning to the second.
             [
                 'trainerIdent' => 'Alice',
-                'participantIdents' => ['John', 'Jane']
-            ],/*
+                'participantIdents' => ['John', 'Jake']
+            ],
             [
                 'trainerIdent' => 'Bob',
-                'participantIdents' => []
-            ]*/
+                'participantIdents' => ['Jane', 'Jack']
+            ]
         ];
 
         $this->assertEquals($expected, $result);
+    }
+
+    public function test_proportionalAllocationWhenTrainerCapacitiesDiffer()
+    {
+        // given: 3 participants with no preferences, one trainer with capacity 4 and one
+        // with capacity 2 - both equally good for every participant
+        $trainerCapacities = [['SmallTeam', 2], ['BigTeam', 4]];
+        $participantWishes = [
+            ['John'], ['Jane'], ['Jack']
+        ];
+        $numberOfWishes = 0;
+        $forbiddenWishes = [];
+        $defaultPriority = 10;
+
+        // when
+        $result = $this->allocator->tryToAllocateFeedbacks(
+            $trainerCapacities,
+            $participantWishes,
+            $numberOfWishes,
+            $forbiddenWishes,
+            $defaultPriority
+        );
+
+        // then: both trainers end up equally busy proportionally (50%: 2 of 4, 1 of 2)
+        // rather than equally busy in absolute terms (which would leave SmallTeam booked
+        // out and BigTeam at only 25%, e.g. 1/4 vs 2/2)
+        $countsByTrainer = array_combine(
+            array_column($result, 'trainerIdent'),
+            array_map(fn($assignment) => count($assignment['participantIdents']), $result)
+        );
+        $this->assertEquals(['SmallTeam' => 1, 'BigTeam' => 2], $countsByTrainer);
     }
 
     public function test_noTrainerAssignmentPossible()
@@ -634,11 +668,11 @@ class FeedbackAllocatorTest extends TestCase
                     ],
                     [
                         'trainerIdent' => 'Salz',
-                        'participantIdents' => ['Fanta', 'Zucker', 'Honig']
+                        'participantIdents' => ['Haribo', 'Zucker', 'Honig']
                     ],
                     [
                         'trainerIdent' => 'Paprika',
-                        'participantIdents' => ['Haribo', 'Schoggi', 'Gummibär']
+                        'participantIdents' => ['Schoggi', 'Gummibär']
                     ],
                     [
                         'trainerIdent' => 'Käse',
@@ -646,7 +680,7 @@ class FeedbackAllocatorTest extends TestCase
                     ],
                     [
                         'trainerIdent' => 'Salzstange',
-                        'participantIdents' => ['Coke']
+                        'participantIdents' => ['Fanta', 'Coke']
                     ]
                 ]
             ],


### PR DESCRIPTION
Instead of piling many feedbacks onto the first few trainers (#394)

Der Flow-Graph sieht neu so aus:

```mermaid
flowchart LR
    S["source<br/>(balance = +N)"]
    K["sink<br/>(balance = −N)"]

    S -->|"cap=1, cost=0"| P1["participant 1"]
    S -->|"cap=1, cost=0"| P2["participant 2"]
    S -->|"cap=1, cost=0"| P3["participant 3"]

    P2 -->|"cost=1 (top wish)"| T1["trainer A"]
    P2 -->|"cost=100 (default)"| T2["trainer B"]
    P1 -->|"cost=2"| T1
    P3 -->|"cost=1"| T1
    P3 -->|"cost=100"| T2

    T1 -->|"cap=1, cost=0"| U1["unit 1/2"]
    T1 -->|"cap=1, cost=0"| U2["unit 2/2"]
    T2 -->|"cap=1, cost=0"| U3["unit 1/1"]

    U1 -->|"cost=0"| K
    U2 -->|"cost=0.5"| K
    U3 -->|"cost=0"| K
```

Basically machen wir bei jedem Trainer nicht mehr eine Edge in den Sink, sondern eine pro Kapazität (also wenn ein Trainer Kapa 4 hat, machen wir 4 Edges, via 4 "Unit" Nodes weil graphp keine parallelen Edges unterstützt). Diese Edges zum Sink haben alle die capacity 1 und aufsteigend viel Cost: 0, 0.25, 0.5, 0.75. Diese Kosten haben dann als Tiebreaks einen Einfluss, wenn dieselbe TN mehreren Trainern zugewiesen werden könnte: Wenn ein Trainer mit Kapa 2 erst 1 zugeweisenes Feedback hat, ist er gefühlt schon "voller" als ein Trainer mit Kapa 4 welcher 1 zugewiesenes Feedback hat. In diesem Moment wird dann das nächste "egal" Feedback dem Trainer 2 zugewiesen, weil dort die nächste freie Unit Edge die Kosten 0.25 hat, statt beim ersten Trainer die Unit Kosten 0.5. -> Die Trainers werden proportional zu ihrer Kapazität aufgefüllt.
Wegen der Range zwischen 0 und 1 werden die neuen Kosten aber nie die ganzzahligen Wunsch-Präferenz-Kosten übersteuern.

Siehe auch Doku, wo die Erweiterung auch noch erklärt ist.